### PR TITLE
CSI-108: Improve array interface + set max_connection to 2

### DIFF
--- a/controller/array_action/array_connection_manager.py
+++ b/controller/array_action/array_connection_manager.py
@@ -39,7 +39,7 @@ def _socket_connect_test(ipaddr, port, timeout=1):
 class ArrayConnectionManager(object):
 
     def __init__(self, user, password, endpoint, array_type=None):  # TODO return the params back.
-        self.array_mediator_class_dict = {XIVArrayMediator.ARRAY_TYPE: XIVArrayMediator, SVCArrayMediator.ARRAY_TYPE: SVCArrayMediator}
+        self.array_mediator_class_dict = {XIVArrayMediator.array_type: XIVArrayMediator, SVCArrayMediator.array_type: SVCArrayMediator}
         self.array_type = array_type
         self.user = user
         self.password = password
@@ -78,7 +78,7 @@ class ArrayConnectionManager(object):
         with connection_lock_dict[self.endpoint_key]:  # TODO: when moving to python 3 - add timeout to the lock!
             if self.endpoint_key in array_connections_dict:
 
-                if array_connections_dict[self.endpoint_key] < med_class.CONNECTION_LIMIT:
+                if array_connections_dict[self.endpoint_key] < med_class.max_connections:
                     logger.debug("adding new connection ")
                     array_connections_dict[self.endpoint_key] += 1
 
@@ -107,7 +107,7 @@ class ArrayConnectionManager(object):
 
     def detect_array_type(self):
         logger.debug("detecting array connection type")
-        for storage_type, port in [(XIVArrayMediator.ARRAY_TYPE, XIVArrayMediator.PORT), (SVCArrayMediator.ARRAY_TYPE, XIVArrayMediator.PORT)]:  # ds8k : 8452
+        for storage_type, port in [(XIVArrayMediator.array_type, XIVArrayMediator.port), (SVCArrayMediator.array_type, XIVArrayMediator.port)]:  # ds8k : 8452
             for endpoint in self.endpoints:
                 if _socket_connect_test(endpoint, port) == 0:
                     logger.debug("storage array type is : {0}".format(self.array_type))

--- a/controller/array_action/array_mediator_interface.py
+++ b/controller/array_action/array_mediator_interface.py
@@ -13,10 +13,9 @@ class ArrayMediator:
             user : user name for connecting to the endpoint
             password : password for connecting to the endpoint
             endpoint : storage array fqdn or ip
-        
-        Errors:
+
+        Raises:
             CredentialsError
-        
         """
         raise NotImplementedError
 
@@ -41,14 +40,13 @@ class ArrayMediator:
         Returns:  
             volume_id : the volume WWN. 
             
-        Errors:
+        Raises:
             VolumeAlreadyExists
             PoolDoesNotExist
             PoolDoesNotMatchCapabilities
             IllegalObjectName
             VolumeNameIsNotSupported 
             PermissionDenied
-
         """
         raise NotImplementedError
 
@@ -60,10 +58,9 @@ class ArrayMediator:
         Args:
             vol_id : wwn of the volume to delete
         
-        Errors:
+        Raises:
             volumeNotFound
             PermissionDenied
-
         """
         raise NotImplementedError
 
@@ -78,11 +75,10 @@ class ArrayMediator:
         Returns:  
            Volume
             
-        Errors:
+        Raises:
             volumeNotFound
             IllegalObjectName
             PermissionDenied
-
         """
         raise NotImplementedError
 
@@ -97,10 +93,9 @@ class ArrayMediator:
         Returns:  
            mapped_host_luns : a dict like this: {<host name>:<lun id>,...}
             
-        Errors:
+        Raises:
             volumeNotFound
             PermissionDenied
-
         """
         raise NotImplementedError
 
@@ -116,12 +111,11 @@ class ArrayMediator:
         Returns:  
            lun : the lun_id the volume was mapped to.
             
-        Errors:
+        Raises:
             noAvailableLun
             volumeNotFound
             hostNotFound
             PermissionDenied
-        
         """
         raise NotImplementedError
 
@@ -133,13 +127,15 @@ class ArrayMediator:
         Args:
            volume_id : the volume WWN.
            host_name : the name of the host to map the volume to.
-        
-        Errors:
+
+        Returns:
+            None
+
+        Raises:
             volumeNotFound
             volAlreadyUnmapped
             hostNotFound
             PermissionDenied
-        
         """
         raise NotImplementedError
 
@@ -156,11 +152,10 @@ class ArrayMediator:
            connectivity_types : list of connectivity types ([iscis, fc] or just [iscsi],..)
            hostname : the name of the host
             
-        Errors:
+        Raises:
             hostNotFound
             multipleHostsFoundError
             PermissionDenied
-
         """
         raise NotImplementedError
 
@@ -173,11 +168,10 @@ class ArrayMediator:
            capabilities : as passed from the storage class
 
         Returns:
+            None
 
-
-        Errors:
+        Raises:
             CapabilityNotSupported
-
         """
         raise NotImplementedError
 

--- a/controller/array_action/array_mediator_interface.py
+++ b/controller/array_action/array_mediator_interface.py
@@ -213,3 +213,12 @@ class ArrayMediator:
         """
         raise NotImplementedError
 
+    @abc.abstractproperty
+    def minimal_volume_size_in_bytes(self):
+        """
+        The minimal volume size in bytes (used in case trying to provision volume with zero size).
+        """
+        raise NotImplementedError
+
+
+

--- a/controller/array_action/array_mediator_interface.py
+++ b/controller/array_action/array_mediator_interface.py
@@ -1,5 +1,6 @@
 import abc
 
+
 class ArrayMediator:
 
     @abc.abstractmethod
@@ -13,12 +14,16 @@ class ArrayMediator:
             password : password for connecting to the endpoint
             endpoint : storage array fqdn or ip
         
-        Returns:  
-            empty.
-            
         Errors:
             CredentialsError
         
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def disconnect(self):
+        """
+        This function disconnect the storage system connection that was opened in the init phase.
         """
         raise NotImplementedError
 
@@ -55,9 +60,6 @@ class ArrayMediator:
         Args:
             vol_id : wwn of the volume to delete
         
-        Returns:  
-           empty
-            
         Errors:
             volumeNotFound
             PermissionDenied
@@ -132,9 +134,6 @@ class ArrayMediator:
            volume_id : the volume WWN.
            host_name : the name of the host to map the volume to.
         
-        Returns:  
-           empty
-            
         Errors:
             volumeNotFound
             volAlreadyUnmapped
@@ -161,19 +160,6 @@ class ArrayMediator:
             hostNotFound
             multipleHostsFoundError
             PermissionDenied
-        
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def get_minimal_volume_size_in_bytes(self):
-        """
-        This function will return the default volume size for volume
-
-        Args:
-
-        Returns:
-           vol size : the minimal size of the volume
 
         """
         raise NotImplementedError
@@ -194,3 +180,36 @@ class ArrayMediator:
 
         """
         raise NotImplementedError
+
+
+
+
+
+    @abc.abstractproperty
+    def array_type(self):
+        """
+        The storage system type.
+        """
+        raise NotImplementedError
+
+    @abc.abstractproperty
+    def port(self):
+        """
+        The storage system managment port number.
+        """
+        raise NotImplementedError
+
+    @abc.abstractproperty
+    def max_vol_name_length(self):
+        """
+        The max number of concurrent connections to the storage system.
+        """
+        raise NotImplementedError
+
+    @abc.abstractproperty
+    def max_connections(self):
+        """
+        The max number of concurrent connections to the storage system.
+        """
+        raise NotImplementedError
+

--- a/controller/array_action/array_mediator_interface.py
+++ b/controller/array_action/array_mediator_interface.py
@@ -23,6 +23,9 @@ class ArrayMediator:
     def disconnect(self):
         """
         This function disconnect the storage system connection that was opened in the init phase.
+
+        Returns:
+            None
         """
         raise NotImplementedError
 
@@ -57,7 +60,10 @@ class ArrayMediator:
         
         Args:
             vol_id : wwn of the volume to delete
-        
+
+        Returns:
+            None
+
         Raises:
             volumeNotFound
             PermissionDenied

--- a/controller/array_action/array_mediator_svc.py
+++ b/controller/array_action/array_mediator_svc.py
@@ -1,7 +1,7 @@
 from array_mediator_interface import  ArrayMediator
 
 class SVCArrayMediator(ArrayMediator):
-    max_connections = 10
+    max_connections = 10  # TODO : need to implement all the interface methods\properties 
     port = 22
     array_type = "svc"
     pass

--- a/controller/array_action/array_mediator_svc.py
+++ b/controller/array_action/array_mediator_svc.py
@@ -1,7 +1,7 @@
 from array_mediator_interface import  ArrayMediator
 
 class SVCArrayMediator(ArrayMediator):
-    CONNECTION_LIMIT = 10
-    PORT = 22
-    ARRAY_TYPE = "svc"
+    max_connections = 10
+    port = 22
+    array_type = "svc"
     pass

--- a/controller/array_action/array_mediator_xiv.py
+++ b/controller/array_action/array_mediator_xiv.py
@@ -12,14 +12,24 @@ logger = get_stdout_logger()
 
 
 class XIVArrayMediator(ArrayMediator):
-    ARRAY_TYPE = 'XIV'
-    PORT = 7778
     ARRAY_ACTIONS = {}
-
     BLOCK_SIZE_IN_BYTES = 512
-    CONNECTION_LIMIT = 3
-    MAX_CONNECTION_RETRY = 3
-    MAX_VOL_NAME_LENGTH = 63
+
+    @property
+    def array_type(self):
+       return 'XIV'
+
+    @property
+    def port(self):
+       return 7778
+
+    @property
+    def max_vol_name_length(self):
+       return 63
+
+    @property
+    def max_connections(self):
+       return 2
 
     def __init__(self, user, password, endpoint):
         self.user = user
@@ -57,7 +67,7 @@ class XIVArrayMediator(ArrayMediator):
                       cli_volume.name,
                       self.endpoint,
                       cli_volume.pool_name,
-                      self.ARRAY_TYPE)
+                      self.array_type)
 
     def get_volume(self, vol_name):
         logger.debug("Get volume : {}".format(vol_name))

--- a/controller/array_action/array_mediator_xiv.py
+++ b/controller/array_action/array_mediator_xiv.py
@@ -31,6 +31,10 @@ class XIVArrayMediator(ArrayMediator):
     def max_connections(self):
        return 2
 
+    @property
+    def minimal_volume_size_in_bytes(self):
+        return 1 * 1024 * 1024 * 1024  # 1 GiB
+
     def __init__(self, user, password, endpoint):
         self.user = user
         self.password = password
@@ -95,9 +99,6 @@ class XIVArrayMediator(ArrayMediator):
     def _convert_size_bytes_to_blocks(self, size_in_bytes):
         """:rtype: float"""
         return float(size_in_bytes) / self.BLOCK_SIZE_IN_BYTES
-
-    def get_minimal_volume_size_in_bytes(self):
-        return 1 * 1024 * 1024 * 1024  # 1 GiB
 
     def create_volume(self, name, size_in_bytes, capabilities, pool):
         logger.info("creating volume with name : {}. size : {} . in pool : {} with capabilities : {}".format(

--- a/controller/controller_server/csi_controller_server.py
+++ b/controller/controller_server/csi_controller_server.py
@@ -67,10 +67,10 @@ class ControllerServicer(csi_pb2_grpc.ControllerServicer):
             with ArrayConnectionManager(user, password, array_addresses) as array_mediator:
                 logger.debug(array_mediator)
 
-                if len(volume_name) > array_mediator.MAX_VOL_NAME_LENGTH:
-                    volume_name = volume_name[:array_mediator.MAX_VOL_NAME_LENGTH]
+                if len(volume_name) > array_mediator.max_vol_name_length:
+                    volume_name = volume_name[:array_mediator.max_vol_name_length]
                     logger.warning("volume name is too long - cutting it to be of size : {0}. new name : {1}".format(
-                        array_mediator.MAX_VOL_NAME_LENGTH, volume_name))
+                        array_mediator.max_vol_name_length, volume_name))
 
                 size = request.capacity_range.required_bytes
 

--- a/controller/controller_server/csi_controller_server.py
+++ b/controller/controller_server/csi_controller_server.py
@@ -75,7 +75,7 @@ class ControllerServicer(csi_pb2_grpc.ControllerServicer):
                 size = request.capacity_range.required_bytes
 
                 if size == 0:
-                    size = array_mediator.get_minimal_volume_size_in_bytes()
+                    size = array_mediator.minimal_volume_size_in_bytes
                     logger.debug("requested size is 0 so the default size will be used : {0} ".format(
                         size))
                 try:

--- a/controller/tests/array_action/array_connection_manager_test.py
+++ b/controller/tests/array_action/array_connection_manager_test.py
@@ -11,7 +11,7 @@ class TestWithFunctionality(unittest.TestCase):
 
     def setUp(self):
         self.fqdn = "fqdn"
-        self.array_connection = ArrayConnectionManager("user", "password", [self.fqdn, self.fqdn] , XIVArrayMediator.ARRAY_TYPE)
+        self.array_connection = ArrayConnectionManager("user", "password", [self.fqdn, self.fqdn] , XIVArrayMediator.array_type)
 
     @patch("controller.array_action.array_connection_manager.XIVArrayMediator._connect")
     @patch("controller.array_action.array_connection_manager.XIVArrayMediator.disconnect")
@@ -40,7 +40,7 @@ class TestGetconnection(unittest.TestCase):
         self.fqdn = "fqdn"
         self.connections = [self.fqdn, self.fqdn]
         self.connection_key = ",".join(self.connections )
-        self.array_connection = ArrayConnectionManager("user", "password", self.connections, XIVArrayMediator.ARRAY_TYPE)
+        self.array_connection = ArrayConnectionManager("user", "password", self.connections, XIVArrayMediator.array_type)
         array_connection_manager.array_connections_dict = {}
 
     def tearDown(self):
@@ -53,7 +53,7 @@ class TestGetconnection(unittest.TestCase):
         self.assertEqual(array_connection_manager.array_connections_dict, {self.connection_key: 1})
 
         new_fqdn = "new-fqdn"
-        array_connection2 = ArrayConnectionManager("user", "password",[new_fqdn], XIVArrayMediator.ARRAY_TYPE)
+        array_connection2 = ArrayConnectionManager("user", "password",[new_fqdn], XIVArrayMediator.array_type)
 
         array_connection2.get_array_connection()
         self.assertEqual(array_connection_manager.array_connections_dict, { self.connection_key: 1, new_fqdn: 1})
@@ -70,7 +70,7 @@ class TestGetconnection(unittest.TestCase):
     @patch("controller.array_action.array_connection_manager.XIVArrayMediator._connect")
     def test_connection_returns_error_on_too_many_connection(self, connect):
         array_connection_manager.array_connections_dict = {
-            self.connection_key: array_connection_manager.XIVArrayMediator.CONNECTION_LIMIT}
+            self.connection_key: array_connection_manager.XIVArrayMediator.max_connections}
         with self.assertRaises(NoConnectionAvailableException):
             self.array_connection.get_array_connection()
 
@@ -89,13 +89,13 @@ class TestGetconnection(unittest.TestCase):
         socket_connet.side_effect = [0, 1]
 
         res = self.array_connection.detect_array_type()
-        self.assertEqual(res, XIVArrayMediator.ARRAY_TYPE)
+        self.assertEqual(res, XIVArrayMediator.array_type)
 
         socket_connet.side_effect = [1, 1, 0, 0]
 
 
         res = self.array_connection.detect_array_type()
-        self.assertEqual(res, SVCArrayMediator.ARRAY_TYPE)
+        self.assertEqual(res, SVCArrayMediator.array_type)
 
         socket_connet.side_effect = [1, 1, 1, 1]
         with self.assertRaises(FailedToFindStorageSystemType):

--- a/controller/tests/controller_server/csi_controller_server_test.py
+++ b/controller/tests/controller_server/csi_controller_server_test.py
@@ -212,7 +212,7 @@ class TestControllerServerCreateVolume(unittest.TestCase):
         array_type.return_value = "a9k"
         res = self.servicer.CreateVolume(self.request, context)
         self.assertEqual(context.code, grpc.StatusCode.OK)
-        self.mediator.get_volume.assert_called_once_with("a" * self.mediator.MAX_VOL_NAME_LENGTH)
+        self.mediator.get_volume.assert_called_once_with("a" * self.mediator.max_vol_name_length)
 
     def test_create_volume_with_illegal_object_name_exception(self):
         self.create_volume_returns_error(return_code=grpc.StatusCode.INVALID_ARGUMENT, err=IllegalObjectName("vol"))


### PR DESCRIPTION
This PR is mainly refactor the array interface to use abstractproperty and also set max_connection=3.

Full detail below:
1. Update max_connections from 3 to 2 (based on architecture review)

2. Add missing interface - disconnect().  It was implemented by xiv mediator but was not exist in the interface.

3. Refactor few consts that were specified in the array specific mediator to be a formal 
 abc.abstractproperty of the mediator interface. So every mediator will have to implement it. Here is the list of attributes (old -> new):
   - ARRAY_TYPE -> array_type
   - CONNECTION_LIMIT -> max_connection
   - PORT -> port
   - MAX_VOL_NAME_LENGHT -> max_vol_name_length

4. Refactor function minimal_volume_size_in_bytes() to be a property of the interface.

5. Remove MAX_CONNECTION_RETRY const from XIV mediator. (was there with no use)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ibm-block-csi-driver/16)
<!-- Reviewable:end -->
