### PR TITLE
Feature/csi node docker build in CI pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
-# ignore .git and .cache folders
-.git
+# ignore .cache folder
 .cache

--- a/Dockerfile-csi-node
+++ b/Dockerfile-csi-node
@@ -24,7 +24,7 @@ COPY go.sum .
 RUN go mod download
 
 COPY . .
-RUN make 
+RUN make ibm-block-csi-driver
 
 # Final stage
 FROM centos:7

--- a/Dockerfile-csi-node
+++ b/Dockerfile-csi-node
@@ -1,0 +1,35 @@
+# Copyright IBM Corporation 2019.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build stage
+FROM golang:1.12.6 as builder
+
+WORKDIR /go/src/github.com/ibm/ibm-block-csi-driver
+ENV GO111MODULE=on
+
+# Populate the module cache based on the go.{mod,sum} files.
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . .
+RUN make 
+
+# Final stage
+FROM centos:7
+WORKDIR /root
+COPY --from=builder /go/src/github.com/ibm/ibm-block-csi-driver/common/config.yaml .
+COPY --from=builder /go/src/github.com/ibm/ibm-block-csi-driver/bin/ibm-block-csi-node-driver .
+
+ENTRYPOINT ["/root/ibm-block-csi-node-driver"]

--- a/Dockerfile-csi-node.test
+++ b/Dockerfile-csi-node.test
@@ -22,6 +22,7 @@ ENV GO111MODULE=on
 COPY go.mod .
 COPY go.sum .
 RUN go mod download
+RUN go get github.com/tebeka/go2xunit   # when GO111MODULE=on the module will not become executable, so get it here to run it as binary.
 
 COPY . .
-RUN make test-xunit
+ENTRYPOINT ["make", "test-xunit"]

--- a/Dockerfile-csi-node.test
+++ b/Dockerfile-csi-node.test
@@ -1,0 +1,27 @@
+# Copyright IBM Corporation 2019.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build stage
+FROM golang:1.12.6 as builder
+
+WORKDIR /go/src/github.com/ibm/ibm-block-csi-driver
+ENV GO111MODULE=on
+
+# Populate the module cache based on the go.{mod,sum} files.
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . .
+RUN make test-xunit

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+# Note: this Makefile currently applicable only for CSI node component.
 PKG=github.com/ibm/ibm-block-csi-driver
 IMAGE=ibmcom/ibm-block-csi-driver
 GIT_COMMIT?=$(shell git rev-parse HEAD)
@@ -33,23 +34,19 @@ ibm-block-csi-driver:
 test:
 	go test -v -race ./node/...
 
-.PHONY: test-xunit
-test-xunit:
-	mkdir -p ./build/reports
-	go test -v -race ./node/... | go2xunit -output build/reports/.csi-node-unitests.xml
-	go test -v -race ./node/...	# run again so the makefile will fail in case tests failing
+.PHONY: test-xunit-in-container
+test-xunit-in-container:
+	docker build -f Dockerfile-csi-node.test -t csi-node-unitests .
+	docker run --rm -t -v $(CURDIR)/build/reports/:/go/src/github.com/ibm/ibm-block-csi-driver/build/reports/ csi-node-unitests
+
 
 .PHONY: gofmt
 gofmt:
 	gofmt -w .
 
-#.PHONY: image-release
-#image-release:
-#	docker build -t $(IMAGE):$(VERSION) .
-#
-#.PHONY: push-release
-#push-release:
-#	docker push $(IMAGE):$(VERSION)
+.PHONY: csi-build-images-and-push-artifactory
+csi-build-images-and-push-artifactory:
+	./scripts/ci/build_push_images.sh
 
 .PHONY: list
 list:

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,12 @@ ibm-block-csi-driver:
 test:
 	go test -v -race ./node/...
 
+.PHONY: test-xunit
+test-xunit:
+	mkdir -p ./driver/coverage/
+	go test -v -race ./node/... | go2xunit -output ./driver/coverage/.unitests.xml
+	go test -v -race ./node/...	# run again so the makefile will fail in case tests failing
+
 .PHONY: gofmt
 gofmt:
 	gofmt -w .

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ test:
 
 .PHONY: test-xunit
 test-xunit:
-	mkdir -p ./driver/coverage/
-	go test -v -race ./node/... | go2xunit -output ./driver/coverage/.unitests.xml
+	mkdir -p ./build/reports
+	go test -v -race ./node/... | go2xunit -output build/reports/.csi-node-unitests.xml
 	go test -v -race ./node/...	# run again so the makefile will fail in case tests failing
 
 .PHONY: gofmt

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,15 @@ ibm-block-csi-driver:
 test:
 	go test -v -race ./node/...
 
+.PHONY: test-xunit
+test-xunit:
+	mkdir -p ./build/reports
+	go test -v -race ./node/... | go2xunit -output build/reports/csi-node-unitests.xml
+	go test -v -race ./node/...	# run again so the makefile will fail in case tests failing
+
 .PHONY: test-xunit-in-container
 test-xunit-in-container:
+    # Run make test-xunit inside csi node container for testing (to avoid go and other testing utils on your laptop).
 	docker build -f Dockerfile-csi-node.test -t csi-node-unitests .
 	docker run --rm -t -v $(CURDIR)/build/reports/:/go/src/github.com/ibm/ibm-block-csi-driver/build/reports/ csi-node-unitests
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@
 # limitations under the License.
 #
 
-# Note: this Makefile currently applicable only for CSI node component.
+# Note: this Makefile currently applicable responsible for CSI compile, test and build image. Later will should add csi-controller to the makefile party.
+
 PKG=github.com/ibm/ibm-block-csi-driver
 IMAGE=ibmcom/ibm-block-csi-driver
 GIT_COMMIT?=$(shell git rev-parse HEAD)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/container-storage-interface/spec v1.1.0
 	github.com/golang/mock v1.1.1
+	github.com/tebeka/go2xunit v1.4.10
 	google.golang.org/grpc v1.21.1
 	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/klog v0.3.3

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/ibm/ibm-block-csi-driver v0.0.0-20190617074002-4a2be9926496 h1:9SV9CXMhrlXiiK8kYe35FnX7pns4zMeNm6UfhrCh8Dw=
+github.com/tebeka/go2xunit v1.4.10/go.mod h1:wmc9jKT7KlU4QLU6DNTaIXNnYNOjKKNlp6mjOS0UrqY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=

--- a/scripts/ci/build_push_images.sh
+++ b/scripts/ci/build_push_images.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 
 # Validations
-MANDATORY_ENVS="IMAGE_VERSION BUILD_NUMBER DOCKER_REGISTRY CSI_CONTROLLER_IMAGE GIT_BRANCH"
+MANDATORY_ENVS="IMAGE_VERSION BUILD_NUMBER DOCKER_REGISTRY CSI_NODE_IMAGE CSI_CONTROLLER_IMAGE GIT_BRANCH"
 for envi in $MANDATORY_ENVS; do 
     [ -z "${!envi}" ] && { echo "Error - Env $envi is mandatory for the script."; exit 1; } || :
 done
@@ -12,6 +12,9 @@ specific_tag="${IMAGE_VERSION}_b${BUILD_NUMBER}_${branch}"
 
 # Set latest tag only if its from develop branch or master and prepare tags
 [ "$GIT_BRANCH" = "develop" -o "$GIT_BRANCH" = "origin/develop" -o "$GIT_BRANCH" = "master" ] && tag_latest="true" || tag_latest="false"
+
+
+# CSI controller
 ctl_registry="${DOCKER_REGISTRY}/${CSI_CONTROLLER_IMAGE}"
 ctl_tag_specific="${ctl_registry}:${specific_tag}"
 ctl_tag_latest=${ctl_registry}:latest
@@ -22,12 +25,25 @@ docker build -t ${ctl_tag_specific} $taglatestflag -f Dockerfile-csi-controller 
 docker push ${ctl_tag_specific}
 [ "$tag_latest" = "true" ] && docker push ${ctl_tag_latest} || :
 
+# CSI node
+node_registry="${DOCKER_REGISTRY}/${CSI_NODE_IMAGE}"
+node_tag_specific="${node_registry}:${specific_tag}"
+node_tag_latest=${node_registry}:latest
+[ "$tag_latest" = "true" ] && taglatestflag="-t ${node_tag_latest}" 
+
+echo "Build and push the CSI node image"
+docker build -t ${node_tag_specific} $taglatestflag -f Dockerfile-csi-controller .
+docker push ${node_tag_specific}
+[ "$tag_latest" = "true" ] && docker push ${node_tag_latest} || :
+
+
 set +x
 echo ""
 echo "Image ready:"
 echo "   ${ctl_tag_specific}"
-[ "$tag_latest" = "true" ] && echo "   ${ctl_tag_latest}" || :
+echo "   ${node_tag_specific}"
+[ "$tag_latest" = "true" ] && { echo "   ${ctl_tag_latest}"; echo "   ${node_tag_latest}"; } || :
 
 # if param $1 given the script echo the specific tag
-[ -n "$1" ] && echo ${ctl_tag_specific} > $1 || :
+[ -n "$1" ] && printf "${ctl_tag_specific}\n${node_tag_specific}\n" > $1 || :
 

--- a/scripts/ci/build_push_images.sh
+++ b/scripts/ci/build_push_images.sh
@@ -15,6 +15,7 @@ specific_tag="${IMAGE_VERSION}_b${BUILD_NUMBER}_${branch}"
 
 
 # CSI controller
+# --------------
 ctl_registry="${DOCKER_REGISTRY}/${CSI_CONTROLLER_IMAGE}"
 ctl_tag_specific="${ctl_registry}:${specific_tag}"
 ctl_tag_latest=${ctl_registry}:latest
@@ -26,13 +27,14 @@ docker push ${ctl_tag_specific}
 [ "$tag_latest" = "true" ] && docker push ${ctl_tag_latest} || :
 
 # CSI node
+# --------
 node_registry="${DOCKER_REGISTRY}/${CSI_NODE_IMAGE}"
 node_tag_specific="${node_registry}:${specific_tag}"
 node_tag_latest=${node_registry}:latest
 [ "$tag_latest" = "true" ] && taglatestflag="-t ${node_tag_latest}" 
 
 echo "Build and push the CSI node image"
-docker build -t ${node_tag_specific} $taglatestflag -f Dockerfile-csi-controller .
+docker build -t ${node_tag_specific} $taglatestflag -f Dockerfile-csi-node .
 docker push ${node_tag_specific}
 [ "$tag_latest" = "true" ] && docker push ${node_tag_latest} || :
 

--- a/scripts/ci/jenkins_pipeline_csi
+++ b/scripts/ci/jenkins_pipeline_csi
@@ -20,6 +20,12 @@ pipeline {
           
             }
         }
+        stage ('CSI-node: go Unit testing') {
+            steps {
+                sh 'mkdir -p build/reports && chmod 777 build/reports'
+                sh 'make test-xunit'
+            }
+        }
         stage ('CSI-deployment: k8s yamls validation') {
             steps {
                 sh './scripts/run_yamlcheck.sh'

--- a/scripts/ci/jenkins_pipeline_csi
+++ b/scripts/ci/jenkins_pipeline_csi
@@ -31,7 +31,7 @@ pipeline {
                 sh './scripts/run_yamlcheck.sh'
             }
         }
-        stage ('CSI-controller: Build and push image') {
+        stage ('CSI-controller & node: Build and push images') {
             steps {
                 sh './scripts/ci/build_push_images.sh build/reports/images_url'
             }

--- a/scripts/ci/jenkins_pipeline_csi
+++ b/scripts/ci/jenkins_pipeline_csi
@@ -23,7 +23,7 @@ pipeline {
         stage ('CSI-node: go Unit testing') {
             steps {
                 sh 'mkdir -p build/reports && chmod 777 build/reports'
-                sh 'make test-xunit'
+                sh 'make test-xunit-in-container'
             }
         }
         stage ('CSI-deployment: k8s yamls validation') {


### PR DESCRIPTION
# Describe
Build csi node as docker image and trigger it as part of the build pipeline in jenkins. So from now on there is ready csi node image in the internal artifactory after every push in git (together with csi controller image which already there).

# Full detail
## new  `Dockerfile-csi-node` file
- Building csi node based on centos7 (maybe we will change to UBI later) and locate the exec inside /root and also copy the config.yaml file.
- Uses multistage build for compilation:
   - Uses go.1.12.6 image
   - Make sure go mod in dedicated docker cache layer to avoid downloading every time.
   - Using `make ibm-block-csi-driver` inside the dockerfile to build the csi node (so dockerfile use the make but also develop can use it locally to compile)
   - Remove .git from .dockerignore in order to have the .git inside the docker image build stage to get the commit hash during the make build.

## new  `Dockerfile-csi-node.test` file
- Almost the same as above but just for running go unit testing inside container during CI pipeline. For that we need parser for xunit and also trigger make test inside the test container.

## Makefile new targets 
- `test-xunit` is for run tests locally and with xunit output
- `test-xunit-in-container` is for run the above inside container in CI pipeline. Which eventually save the xunit of the testing inside $(CURDIR)/build/reports/ so the pipeline collect it to the job.
- `csi-build-images-and-push-artifactory` to run the build and push to registry as a Makefile target (just nice convention instead of script). Adding this target to the CI pipeline.

## scripts/ci/build_push_images.sh updated 
- Now this script build and push csi node image (not only csi controller)

## jenkins_pipeline_csi new phase
1. Adding `CSI-node: go Unit testing` phase in CI pipeline.
2. Update the name of the build phase to `CSI-controller & node: Build and push images` since now it also build the csi node image.
So now the build pipeline look like this(every phase runs in its own container) ->

![image](https://user-images.githubusercontent.com/1079649/60511048-b5983c00-9cd9-11e9-9181-b5a0da57b128.png)



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ibm-block-csi-driver/27)
<!-- Reviewable:end -->
