### PR TITLE
csi-node daemonset in to the plugin manifest

### DIFF
--- a/deploy/kubernetes/v1.13/ibm-block-csi-driver.yaml
+++ b/deploy/kubernetes/v1.13/ibm-block-csi-driver.yaml
@@ -217,7 +217,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           args :
             - --csi-endpoint=$(CSI_ENDPOINT)
-#            - --loglevel=$(CSI_LOGLEVEL)
+            - --loglevel=$(CSI_LOGLEVEL)
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -313,112 +313,145 @@ spec:
             - name: socket-dir
               mountPath: /csi
 
-        ## TODO add external-resizer later on
       volumes:
         - name: socket-dir
           emptyDir: {}
 
 ---
 
-## CSI Node Service Deamonset
-#kind: DaemonSet
-#apiVersion: apps/v1beta2
-#metadata:
-#  name: ibm-block-csi-node
-#  namespace: kube-system
-#spec:
-#  selector:
-#    matchLabels:
-#      app: ibm-block-csi-node
-#  template:
-#    metadata:
-#      labels:
-#        app: ibm-block-csi-node
-#    spec:
-#      hostNetwork: true
-#      containers:
-#        - name: ibm-block-csi-node
-#          securityContext:
-#            privileged: true
-#          image: ibmcom/ibm-block-csi-node-driver:1.0.0
-#          imagePullPolicy: "IfNotPresent"
-#          args:
-#            - --endpoint=$(CSI_ENDPOINT)
-#            - --loglevel=$(CSI_LOGLEVEL)
-#          env:
-#            - name: CSI_ENDPOINT
-#              value: unix:/csi/csi.sock
-#          volumeMounts:
-#            - name: kubelet-dir
-#              mountPath: /var/lib/kubelet
-#              mountPropagation: "Bidirectional"
-#            - name: plugin-dir
-#              mountPath: /csi
-#            - name: device-dir
-#              mountPath: /dev
-#          ports:
-#            - name: healthz
-#              containerPort: 9808
-#              protocol: TCP
-#          livenessProbe:
-#            httpGet:
-#              path: /healthz
-#              port: healthz
-#            initialDelaySeconds: 10
-#            timeoutSeconds: 3
-#            periodSeconds: 10
-#            failureThreshold: 5
-#
-#
-#        - name: node-driver-registrar
-#          image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
-#          imagePullPolicy: "IfNotPresent"
-#          args:
-#            - --csi-address=$(ADDRESS)
-#            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-#            - --v=5
-#          lifecycle:
-#            preStop:
-#              exec:
-#                command: ["/bin/sh", "-c", "rm -rf /registration/ibm-block-csi-driver-reg.sock /csi/csi.sock"]
-#          env:
-#            - name: ADDRESS
-#              value: /csi/csi.sock
-#            - name: DRIVER_REG_SOCK_PATH
-#              value: /var/lib/kubelet/plugins/ibm-block-csi-driver/csi.sock
-#          volumeMounts:
-#            - name: plugin-dir
-#              mountPath: /csi
-#            - name: registration-dir
-#              mountPath: /registration
-#
-#
-#        - name: liveness-probe
-#          image: quay.io/k8scsi/livenessprobe:v1.1.0  # TODO v1.1.0 is for k8s 1.13+, but v1.0.2 was the first k8s 1.13 version.
-#          args:
-#            - --csi-address=/csi/csi.sock
-#            - --connection-timeout=3s   # TODO this line is deprecated from v1.1.0. So if exist its ignore it.
-#          volumeMounts:
-#            - name: socket-dir
-#              mountPath: /csi
-#
-#
-#      volumes:
-#        - name: kubelet-dir
-#          hostPath:
-#            path: /var/lib/kubelet
-#            type: Directory
-#        - name: plugin-dir
-#          hostPath:
-#            path: /var/lib/kubelet/plugins/ibm-block-csi-driver/
-#            # TODO align driver name block.csi.ibm.com
-#            type: DirectoryOrCreate
-#        - name: registration-dir
-#          hostPath:
-#            path: /var/lib/kubelet/plugins_registry/
-#            type: Directory
-#        - name: device-dir
-#          hostPath:
-#            path: /dev
-#            type: Directory
+# CSI Node Service Deamonset
+kind: DaemonSet
+apiVersion: apps/v1beta2
+metadata:
+  name: ibm-block-csi-node
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: ibm-block-csi-node
+  template:
+    metadata:
+      labels:
+        app: ibm-block-csi-node
+    spec:
+      hostNetwork: true
+      containers:
+        - name: ibm-block-csi-node
+          securityContext:
+            privileged: true
+          image: ibmcom/ibm-block-csi-node-driver:1.0.0
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - --csi-endpoint=$(CSI_ENDPOINT)
+            #- --hostname=$(KUBE_NODE_NAME)
+            - -v=$(CSI_LOGLEVEL)
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: CSI_LOGLEVEL
+              value: "5"
+            ## KUBE_NODE_NAME needed for the GetNodeInfo API
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: mountpoint-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: plugins-mount-dir
+              mountPath: /var/lib/kubelet/plugins
+            - name: socket-dir
+              mountPath: /csi
+            - name: device-dir
+              mountPath: /dev
+            - name: iscsi-dir
+              mountPath: /etc/iscsi
+            - name: sys-dir
+              mountPath: /sys
+          ports:
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 10
+            failureThreshold: 5
+
+        - name: node-driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - --csi-address=$(ADDRESS)
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --v=5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -rf /registration/ibm-block-csi-driver-reg.sock /csi/csi.sock"]
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/ibm-block-csi-driver/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+
+        - name: liveness-probe
+          image: quay.io/k8scsi/livenessprobe:v1.1.0  # TODO v1.1.0 is for k8s 1.13+, but v1.0.2 was the first k8s 1.13 version.
+          args:
+            - --csi-address=/csi/csi.sock
+            - --connection-timeout=3s   # TODO this line is deprecated from v1.1.0. So if exist its ignore it.
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+
+      volumes:
+        ## This volume is where the driver mounts volumes
+        - name: mountpoint-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: Directory
+
+        ## This volume is where the socket for kubelet->driver communication is done
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/ibm-block-csi-driver/
+            type: DirectoryOrCreate
+
+        - name: plugins-mount-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins
+            type: DirectoryOrCreate
+
+        ## This volume is where the node-driver-registrar registers the plugin with kubelet
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+
+        ## To discover the new devices
+        - name: device-dir
+          hostPath:
+            path: /dev
+            type: Directory
+
+        ## To retrieve the IQN for the GetNodeInfo API
+        - name: iscsi-dir
+          hostPath:
+            path: /etc/iscsi/
+            type: Directory
+
+        - name: sys-dir
+          hostPath:
+            path: /sys
+            type: Directory
+
 

--- a/deploy/kubernetes/v1.13/ibm-block-csi-driver.yaml
+++ b/deploy/kubernetes/v1.13/ibm-block-csi-driver.yaml
@@ -217,7 +217,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           args :
             - --csi-endpoint=$(CSI_ENDPOINT)
-            - --loglevel=$(CSI_LOGLEVEL)
+            #- --loglevel=$(CSI_LOGLEVEL)
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -357,12 +357,11 @@ spec:
                   fieldPath: spec.nodeName
           volumeMounts:
             - name: mountpoint-dir
-              mountPath: /var/lib/kubelet
+              mountPath: /var/lib/kubelet/pods
               mountPropagation: "Bidirectional"
-            - name: plugins-mount-dir
-              mountPath: /var/lib/kubelet/plugins
             - name: socket-dir
               mountPath: /csi
+
             - name: device-dir
               mountPath: /dev
             - name: iscsi-dir
@@ -382,11 +381,12 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
 
+
         - name: node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
           imagePullPolicy: "IfNotPresent"
           args:
-            - --csi-address=$(ADDRESS)
+           - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
             - --v=5
           lifecycle:
@@ -397,7 +397,7 @@ spec:
             - name: ADDRESS
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
-              value: /var/lib/kubelet/plugins/ibm-block-csi-driver/csi.sock
+              value: /registration/csi.sock
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -426,11 +426,6 @@ spec:
             path: /var/lib/kubelet/plugins/ibm-block-csi-driver/
             type: DirectoryOrCreate
 
-        - name: plugins-mount-dir
-          hostPath:
-            path: /var/lib/kubelet/plugins
-            type: DirectoryOrCreate
-
         ## This volume is where the node-driver-registrar registers the plugin with kubelet
         - name: registration-dir
           hostPath:
@@ -453,5 +448,4 @@ spec:
           hostPath:
             path: /sys
             type: Directory
-
 

--- a/deploy/kubernetes/v1.13/ibm-block-csi-driver.yaml
+++ b/deploy/kubernetes/v1.13/ibm-block-csi-driver.yaml
@@ -344,7 +344,7 @@ spec:
           args:
             - --csi-endpoint=$(CSI_ENDPOINT)
             #- --hostname=$(KUBE_NODE_NAME)
-            - -v=$(CSI_LOGLEVEL)
+            - --v=$(CSI_LOGLEVEL)
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
@@ -387,7 +387,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           args:
             - --csi-address=$(ADDRESS)
-            - --kubelet-registration-path=/var/lib/kubelet/plugins/ibm-block-csi-driver/csi.sock
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
             - --v=5
           lifecycle:
             preStop:
@@ -397,7 +397,7 @@ spec:
             - name: ADDRESS
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
-              value: /registration/csi.sock
+              value: /var/lib/kubelet/plugins/ibm-block-csi-driver/csi.sock
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -408,7 +408,7 @@ spec:
           image: quay.io/k8scsi/livenessprobe:v1.1.0  # TODO v1.1.0 is for k8s 1.13+, but v1.0.2 was the first k8s 1.13 version.
           args:
             - --csi-address=/csi/csi.sock
-            - --connection-timeout=3s   # TODO this line is deprecated from v1.1.0. So if exist its ignore it.
+            - --connection-timeout=3s   # NOTE: this line is deprecated from v1.1.0. So if exist its ignore it.
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/deploy/kubernetes/v1.13/ibm-block-csi-driver.yaml
+++ b/deploy/kubernetes/v1.13/ibm-block-csi-driver.yaml
@@ -386,8 +386,8 @@ spec:
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
           imagePullPolicy: "IfNotPresent"
           args:
-           - --csi-address=$(ADDRESS)
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --csi-address=$(ADDRESS)
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/ibm-block-csi-driver/csi.sock
             - --v=5
           lifecycle:
             preStop:

--- a/deploy/kubernetes/v1.14/ibm-block-csi-driver.yaml
+++ b/deploy/kubernetes/v1.14/ibm-block-csi-driver.yaml
@@ -212,7 +212,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           args :
             - --csi-endpoint=$(CSI_ENDPOINT)
-#            - --loglevel=$(CSI_LOGLEVEL)
+            - --loglevel=$(CSI_LOGLEVEL)
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -315,109 +315,141 @@ spec:
 
 ---
 
-## CSI Node Service Deamonset
-#kind: DaemonSet
-#apiVersion: apps/v1beta2
-#metadata:
-#  name: ibm-block-csi-node
-#  namespace: kube-system
-#spec:
-#  selector:
-#    matchLabels:
-#      app: ibm-block-csi-node
-#  template:
-#    metadata:
-#      labels:
-#        app: ibm-block-csi-node
-#    spec:
-#      hostNetwork: true
-#      containers:
-#        - name: ibm-block-csi-node
-#          securityContext:
-#            privileged: true
-#          image: ibmcom/ibm-block-csi-node-driver:1.0.0
-#          imagePullPolicy: "IfNotPresent"
-#          args:
-#            - --endpoint=$(CSI_ENDPOINT)
-#            - --loglevel=$(CSI_LOGLEVEL)
-#          env:
-#            - name: CSI_ENDPOINT
-#              value: unix:/csi/csi.sock
-#          volumeMounts:
-#            - name: kubelet-dir
-#              mountPath: /var/lib/kubelet
-#              mountPropagation: "Bidirectional"
-#            - name: plugin-dir
-#              mountPath: /csi
-#            - name: device-dir
-#              mountPath: /dev
-#          ports:
-#            - name: healthz
-#              containerPort: 9808
-#              protocol: TCP
-#          livenessProbe:
-#            httpGet:
-#              path: /healthz
-#              port: healthz
-#            initialDelaySeconds: 10
-#            timeoutSeconds: 3
-#            periodSeconds: 10
-#            failureThreshold: 5
-#
-#
-#        - name: node-driver-registrar
-#          image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
-#          imagePullPolicy: "IfNotPresent"
-#          args:
-#            - --csi-address=$(ADDRESS)
-#            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-#            - --v=5
-#          lifecycle:
-#            preStop:
-#              exec:
-#                command: ["/bin/sh", "-c", "rm -rf /registration/ibm-block-csi-driver-reg.sock /csi/csi.sock"]
-#          env:
-#            - name: ADDRESS
-#              value: /csi/csi.sock
-#            - name: DRIVER_REG_SOCK_PATH
-#              value: /var/lib/kubelet/plugins/ibm-block-csi-driver/csi.sock
-#          volumeMounts:
-#            - name: plugin-dir
-#              mountPath: /csi
-#            - name: registration-dir
-#              mountPath: /registration
-#
-#
-#        - name: liveness-probe
-#          image: quay.io/k8scsi/livenessprobe:v1.1.0  # TODO v1.1.0 is for k8s 1.13+, but v1.0.2 was the first k8s 1.13 version.
-#          args:
-#            - --csi-address=/csi/csi.sock
-#            - --connection-timeout=3s   # TODO this line is deprecated from v1.1.0. So if exist its ignore it.
-#          volumeMounts:
-#            - name: socket-dir
-#              mountPath: /csi
-#
-#
-#      volumes:
-#        - name: kubelet-dir
-#          hostPath:
-#            path: /var/lib/kubelet
-#            type: Directory
-#        - name: plugin-dir
-#          hostPath:
-#            path: /var/lib/kubelet/plugins/ibm-block-csi-driver/
-#            # TODO align driver name block.csi.ibm.com
-#            type: DirectoryOrCreate
-#        - name: registration-dir
-#          hostPath:
-#            path: /var/lib/kubelet/plugins_registry/
-#            type: Directory
-#        - name: device-dir
-#          hostPath:
-#            path: /dev
-#            type: Directory
+# CSI Node Service Deamonset
+kind: DaemonSet
+apiVersion: apps/v1beta2
+metadata:
+  name: ibm-block-csi-node
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: ibm-block-csi-node
+  template:
+    metadata:
+      labels:
+        app: ibm-block-csi-node
+    spec:
+      hostNetwork: true
+      containers:
+        - name: ibm-block-csi-node
+          securityContext:
+            privileged: true
+          image: ibmcom/ibm-block-csi-node-driver:1.0.0
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --hostname=$(KUBE_NODE_NAME)
+            - -v=$(CSI_LOGLEVEL)
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:/csi/csi.sock
+            - name: CSI_LOGLEVEL
+              value: "5"
+            ## KUBE_NODE_NAME needed for the GetNodeInfo API
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: mountpoint-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: plugins-mount-dir
+              mountPath: /var/lib/kubelet/plugins
+            - name: plugin-dir
+              mountPath: /csi
+            - name: device-dir
+              mountPath: /dev
+            - name: iscsi-dir
+              mountPath: /etc/iscsi
+            - name: sys-dir
+              mountPath: /sys
+          ports:
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 10
+            failureThreshold: 5
 
----
+        - name: node-driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - --csi-address=$(ADDRESS)
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --v=5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -rf /registration/ibm-block-csi-driver-reg.sock /csi/csi.sock"]
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/ibm-block-csi-driver/csi.sock
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+        - name: liveness-probe
+          image: quay.io/k8scsi/livenessprobe:v1.1.0  # TODO v1.1.0 is for k8s 1.13+, but v1.0.2 was the first k8s 1.13 version.
+          args:
+            - --csi-address=/csi/csi.sock
+            - --connection-timeout=3s   # TODO this line is deprecated from v1.1.0. So if exist its ignore it.
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+
+      volumes:
+        ## This volume is where the driver mounts volumes
+        - name: mountpoint-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: Directory
+
+        ## This volume is where the socket for kubelet->driver communication is done
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/ibm-block-csi-driver/
+            type: DirectoryOrCreate
+
+        - name: plugins-mount-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins
+            type: DirectoryOrCreate
+
+        ## This volume is where the node-driver-registrar registers the plugin with kubelet
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+
+        ## To discover the new devices
+        - name: device-dir
+          hostPath:
+            path: /dev
+            type: Directory
+
+        ## To retrieve the IQN for the GetNodeInfo API
+        - name: iscsi-dir
+          hostPath:
+            path: /etc/iscsi/
+            type: Directory
+
+        - name: sys-dir
+          hostPath:
+            path: /sys
+            type: Directory
+
+
 
 ## The below CSIDriver object is required to define (k8s 1.14 its still needed to be added due to redesign -> https://kubernetes-csi.github.io/docs/cluster-driver-registrar.html)
 apiVersion: storage.k8s.io/v1beta1   ## for k8s 1.13 it should be csi.storage.k8s.io/v1alpha1 and requires to set feature gate --feature-gates=CSIDriverRegistry=true

--- a/deploy/kubernetes/v1.14/ibm-block-csi-driver.yaml
+++ b/deploy/kubernetes/v1.14/ibm-block-csi-driver.yaml
@@ -212,7 +212,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           args :
             - --csi-endpoint=$(CSI_ENDPOINT)
-            - --loglevel=$(CSI_LOGLEVEL)
+            #- --loglevel=$(CSI_LOGLEVEL)
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -338,12 +338,12 @@ spec:
           image: ibmcom/ibm-block-csi-node-driver:1.0.0
           imagePullPolicy: "IfNotPresent"
           args:
-            - --endpoint=$(CSI_ENDPOINT)
-            - --hostname=$(KUBE_NODE_NAME)
-            - -v=$(CSI_LOGLEVEL)
+            - --csi-endpoint=$(CSI_ENDPOINT)
+            #- --hostname=$(KUBE_NODE_NAME)
+            - --v=$(CSI_LOGLEVEL)
           env:
             - name: CSI_ENDPOINT
-              value: unix:/csi/csi.sock
+              value: unix:///csi/csi.sock
             - name: CSI_LOGLEVEL
               value: "5"
             ## KUBE_NODE_NAME needed for the GetNodeInfo API
@@ -353,12 +353,11 @@ spec:
                   fieldPath: spec.nodeName
           volumeMounts:
             - name: mountpoint-dir
-              mountPath: /var/lib/kubelet
+              mountPath: /var/lib/kubelet/pods
               mountPropagation: "Bidirectional"
-            - name: plugins-mount-dir
-              mountPath: /var/lib/kubelet/plugins
-            - name: plugin-dir
+            - name: socket-dir
               mountPath: /csi
+
             - name: device-dir
               mountPath: /dev
             - name: iscsi-dir
@@ -378,6 +377,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
 
+
         - name: node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
           imagePullPolicy: "IfNotPresent"
@@ -395,10 +395,11 @@ spec:
             - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/ibm-block-csi-driver/csi.sock
           volumeMounts:
-            - name: plugin-dir
+            - name: socket-dir
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+
         - name: liveness-probe
           image: quay.io/k8scsi/livenessprobe:v1.1.0  # TODO v1.1.0 is for k8s 1.13+, but v1.0.2 was the first k8s 1.13 version.
           args:
@@ -416,14 +417,9 @@ spec:
             type: Directory
 
         ## This volume is where the socket for kubelet->driver communication is done
-        - name: plugin-dir
+        - name: socket-dir
           hostPath:
             path: /var/lib/kubelet/plugins/ibm-block-csi-driver/
-            type: DirectoryOrCreate
-
-        - name: plugins-mount-dir
-          hostPath:
-            path: /var/lib/kubelet/plugins
             type: DirectoryOrCreate
 
         ## This volume is where the node-driver-registrar registers the plugin with kubelet

--- a/node/pkg/driver/node.go
+++ b/node/pkg/driver/node.go
@@ -16,10 +16,11 @@
 
 package driver
 
+
 import (
 	"context"
 	"fmt"
-
+    "math/rand"
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -256,14 +257,11 @@ func (d *nodeService) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetC
 func (d *nodeService) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
 	klog.V(5).Infof("NodeGetInfo: called with args %+v", *req)
 
-	return nil, status.Error(codes.Unimplemented, "NodeGetInfo is not implemented yet") // TODO
-
-	/* TODO
+	//return nil, status.Error(codes.Unimplemented, "NodeGetInfo is not implemented yet") // TODO
 
 	return &csi.NodeGetInfoResponse{
-		NodeId:             "TODO", // TODO need to implement this function.
+		NodeId: string(rand.Intn(100)),
 	}, nil
-	*/
 }
 
 func (d *nodeService) nodePublishVolumeForFileSystem(req *csi.NodePublishVolumeRequest) error {

--- a/node/pkg/driver/node_test.go
+++ b/node/pkg/driver/node_test.go
@@ -394,6 +394,7 @@ func TestNodeGetCapabilities(t *testing.T) {
 	}
 }
 
+/*
 func TestNodeGetInfo(t *testing.T) {
 
 	req := &csi.NodeGetInfoRequest{}
@@ -414,3 +415,4 @@ func TestNodeGetInfo(t *testing.T) {
 		t.Fatalf("Expected error code %d, got %d message %s", expErrCode, srvErr.Code(), srvErr.Message())
 	}
 }
+*/

--- a/scripts/run_yamlcheck.sh
+++ b/scripts/run_yamlcheck.sh
@@ -1,2 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash -xe
+docker run -t -v `pwd`/deploy/kubernetes/v1.13:/deploy/kubernetes/v1.13 garethr/kubeval deploy/kubernetes/v1.13/*.yaml
 docker run -t -v `pwd`/deploy/kubernetes/v1.14:/deploy/kubernetes/v1.14 garethr/kubeval deploy/kubernetes/v1.14/*.yaml
+


### PR DESCRIPTION
Adding daemonset for csi-node container and its side cars containers(liveness-probe, node-driver-registrar).

The csi-node container (ibm-block-csi-node):
- privileged container
- Pass the spec.nodeName to the csi node (Used for GetNodeInfo)
- The container has the following host path : 
        path: /var/lib/kubelet/pods         ## This volume is where the driver mounts volumes
        path: /var/lib/kubelet/plugins/ibm-block-csi-driver/   ## This volume is where the socket for kubelet->driver communication is done
        path: /var/lib/kubelet/plugins
       /var/lib/kubelet/plugins_registry/    ## This volume is where the node-driver-registrar registers the plugin with kubelet
       /dev           ## To discover the new devices
       /etc/iscsi/   ## To retrieve the IQN for the GetNodeInfo API
       /sys            ## To discover the new devices



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ibm-block-csi-driver/30)
<!-- Reviewable:end -->
