### PR TITLE
Fix\change python entrypoint to use python3.6

### DIFF
--- a/controller/scripts/entrypoint.sh
+++ b/controller/scripts/entrypoint.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-exec python /driver/controller/controller_server/csi_controller_server.py $@
+exec python3.6 /driver/controller/controller_server/csi_controller_server.py $@


### PR DESCRIPTION
change controller entrypoint to  use python3.6 in the entrypoint script. (instead of default python2)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ibm-block-csi-driver/31)
<!-- Reviewable:end -->
