### PR TITLE
upgrade pip3 version for Dockerfile-csi-controller.test

### DIFF
--- a/Dockerfile-csi-controller.test
+++ b/Dockerfile-csi-controller.test
@@ -21,6 +21,7 @@ FROM centos:7
 RUN yum --enablerepo=extras -y install epel-release && yum -y install python36-pip
 
 COPY controller/requirements.txt /driver/controller/
+RUN pip3 install --upgrade pip==19.1.1
 RUN pip3 install -r /driver/controller/requirements.txt
 
 # Requires to run unit testing


### PR DESCRIPTION
HI @ranhrl , like the Dockerfile-csi-controller,  pip3 in Dockerfile-csi-controller.test also need to upgrade to 19.1.1. other wise gcc error will be thrown

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ibm-block-csi-driver/36)
<!-- Reviewable:end -->
