### PR TITLE
Refactor - NodePublishVolume will do the mount instead of NodeStage

### DIFF
--- a/node/pkg/driver/device_connectivity/errors.go
+++ b/node/pkg/driver/device_connectivity/errors.go
@@ -35,7 +35,7 @@ type ConnectivityIscsiStorageTargetNotFoundError struct {
 }
 
 func (e *ConnectivityIscsiStorageTargetNotFoundError) Error() string {
-	return fmt.Sprintf("Connectivity Error: Storage target name [%s] was not found on the host, under directory %s", e.StorageTargetName, e.DirectoryPath)
+	return fmt.Sprintf("Connectivity Error: Storage target name [%s] was not found on the host, under directory %s. Please check the host connectivity to the storage.", e.StorageTargetName, e.DirectoryPath)
 }
 
 type MultipleDeviceNotFoundError struct {
@@ -44,7 +44,7 @@ type MultipleDeviceNotFoundError struct {
 }
 
 func (e *MultipleDeviceNotFoundError) Error() string {
-	return fmt.Sprintf("Couldn't find dm-* of the physical device path [%s -> %s] ", e.DiskByPathDevice, e.LinkToPhysicalDevice)
+	return fmt.Sprintf("Couldn't find dm-* of the physical device path [%s -> %s]. Please check the host connectivity to the storage.", e.DiskByPathDevice, e.LinkToPhysicalDevice)
 }
 
 type ErrorNothingWasWrittenToScanFileError struct {

--- a/node/pkg/driver/node.go
+++ b/node/pkg/driver/node.go
@@ -317,7 +317,7 @@ func (d *NodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	mountList, err := d.mounter.List()
 	for _, mount := range mountList {
-		klog.V(5).Infof("mount device : {%v}, path : {%v} is equel to targetPath {%s}", mount.Device, mount.Path, targetPath)
+		klog.V(5).Infof("Check if mount device({%v}) \path({%v}) is equel to targetPath {%s}", mount.Device, mount.Path, targetPath)
 		if strings.TrimPrefix(mount.Path, "/host") == targetPath {
 			// Trim /host due to the mount of the / from the host into the /host mountpoint inside the csi node container.
 			klog.Warningf("Idempotent case : targetPath already mounted (%s), so no need to mount again. Finish NodePublishVolume.", targetPath)

--- a/node/pkg/driver/node.go
+++ b/node/pkg/driver/node.go
@@ -141,27 +141,27 @@ func (d *NodeService) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		klog.V(4).Infof("Target path directory does not exist. creating : {%v}", stagingPath)
 		d.mounter.MakeDir(stagingPath) // TODO consider to chmod the directory
 	} else {
-		// checking idempotent case 
+		// checking idempotent case
 		_, err := os.Stat(stageInfoPath)
 		if err == nil {
 			klog.V(4).Infof("Idempotent case: node stage was already called before on this path. checking stage info")
-			// lets read the file and comprae the stageInfo 
+			// lets read the file and comprae the stageInfo
 			existingStageInfo, err := d.NodeUtils.ReadFromStagingInfoFile(stageInfoPath)
-			if err != nil{
-				klog.Warningf("could not read and compare the info inside the staging info file : {%v}. error : {%v}",stageInfoPath, err)
+			if err != nil {
+				klog.Warningf("could not read and compare the info inside the staging info file : {%v}. error : {%v}", stageInfoPath, err)
 			}
-			if (stageInfo["mpathDevice"] !=  existingStageInfo["mpathDevice"])|| 
-			(stageInfo["sysDevices"] != existingStageInfo["sysDevices"]) ||  
-			(stageInfo["connectivity"] != existingStageInfo["connectivity"] ){
-				klog.Errorf("stage info is not as expected. expected:  {%v}. got : {%v}", stageInfo,existingStageInfo )
-				return nil, status.Error(codes.AlreadyExists, err.Error())	
+			if (stageInfo["mpathDevice"] != existingStageInfo["mpathDevice"]) ||
+				(stageInfo["sysDevices"] != existingStageInfo["sysDevices"]) ||
+				(stageInfo["connectivity"] != existingStageInfo["connectivity"]) {
+				klog.Errorf("stage info is not as expected. expected:  {%v}. got : {%v}", stageInfo, existingStageInfo)
+				return nil, status.Error(codes.AlreadyExists, err.Error())
 			}
 		}
 	}
 
-	if err := d.NodeUtils.WriteStageInfoToFile(stageInfoPath, stageInfo); err != nil{
+	if err := d.NodeUtils.WriteStageInfoToFile(stageInfoPath, stageInfo); err != nil {
 		klog.Errorf("Error while trying to save the stage metadata file [%s]: {%v}", stageInfoPath, err.Error())
-		return nil, status.Error(codes.Internal, err.Error())		
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	klog.V(4).Infof("NodeStageVolume Finished: multipath device is ready [%s] to be mounted by NodePublishVolume API.", baseDevice)
@@ -302,10 +302,6 @@ func (d *NodeService) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 	return &csi.NodeUnstageVolumeResponse{}, nil
 }
 
-
-
-
-
 func (d *NodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
 	klog.V(5).Infof("NodePublishVolume: called with args %+v", *req)
 
@@ -343,27 +339,27 @@ func (d *NodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	}
 
 	/*
-	dev, refs, err := mount.GetDeviceNameFromMount(d.mounter, stagingPath)
-	klog.V(4).Infof("dev : {%v}. refs : {%v}", dev, refs)
-	if err != nil {
-		klog.Errorf("Error while trying to get device from mount : {%v}", err.Error())
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-
-	if refs != 0 {
-		dmDevice, err := filepath.EvalSymlinks(dev)
+		dev, refs, err := mount.GetDeviceNameFromMount(d.mounter, stagingPath)
+		klog.V(4).Infof("dev : {%v}. refs : {%v}", dev, refs)
 		if err != nil {
-			klog.Errorf("Error while reading symlink : {%v}. err : {%v}", dev, err.Error())
+			klog.Errorf("Error while trying to get device from mount : {%v}", err.Error())
 			return nil, status.Error(codes.Internal, err.Error())
 		}
-		klog.V(4).Infof("comparing dev : {%v} with device : {%v}", dmDevice, device)
-		if dmDevice == device {
-			klog.V(4).Infof("Returning ok result") // TODO double check
-			return &csi.NodeStageVolumeResponse{}, nil
-		} else {
-			return nil, status.Errorf(codes.AlreadyExists, "Mount point is already mounted to.")
+
+		if refs != 0 {
+			dmDevice, err := filepath.EvalSymlinks(dev)
+			if err != nil {
+				klog.Errorf("Error while reading symlink : {%v}. err : {%v}", dev, err.Error())
+				return nil, status.Error(codes.Internal, err.Error())
+			}
+			klog.V(4).Infof("comparing dev : {%v} with device : {%v}", dmDevice, device)
+			if dmDevice == device {
+				klog.V(4).Infof("Returning ok result") // TODO double check
+				return &csi.NodeStageVolumeResponse{}, nil
+			} else {
+				return nil, status.Errorf(codes.AlreadyExists, "Mount point is already mounted to.")
+			}
 		}
-	}
 	*/
 
 	// if the device is not mounted then we are mounting it.
@@ -374,7 +370,6 @@ func (d *NodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	if fsType == "" {
 		fsType = defaultFSType
 	}
-
 
 	// Read staging info file in order to find the mpath device for mounting.
 	stageInfoPath := path.Join(stagingPath, stageInfoFilename)
@@ -404,11 +399,6 @@ func (d *NodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	return &csi.NodePublishVolumeResponse{}, nil
 }
-
-
-
-
-
 
 func (d *NodeService) nodePublishVolumeRequestValidation(req *csi.NodePublishVolumeRequest) error {
 	volumeID := req.GetVolumeId()

--- a/node/pkg/driver/node.go
+++ b/node/pkg/driver/node.go
@@ -317,7 +317,7 @@ func (d *NodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	mountList, err := d.mounter.List()
 	for _, mount := range mountList {
-		klog.V(5).Infof("Check if mount device({%v}) \path({%v}) is equel to targetPath {%s}", mount.Device, mount.Path, targetPath)
+		klog.V(5).Infof("Check if mount path({%v}) [with device({%v})] is equel to targetPath {%s}", mount.Device, mount.Path, targetPath)
 		if strings.TrimPrefix(mount.Path, "/host") == targetPath {
 			// Trim /host due to the mount of the / from the host into the /host mountpoint inside the csi node container.
 			klog.Warningf("Idempotent case : targetPath already mounted (%s), so no need to mount again. Finish NodePublishVolume.", targetPath)


### PR DESCRIPTION
Suggestion for moving the mount operation from the nodestage to the nodepublishvolume.

1. nodestage will do the discovery and also mkfs (and testing mount to nodestage, but after testing it will unmount it). 
2. nodestage creates the nodeinfo file to the stagingTarget directory (which is not mounted!).
3. Nodepublish volume will get the dm device from the nodestage info file (on the stagingPath) and will mount it to the targetPath(the final path of the pod)
4. Nodeunpublishvolume will do the same as before, just unmount the targetPath.
5. nodeunstage will read the stage info file and then delete the dm devices and the sdX devices. (no need to unmount the stagingPath because its never mounted to the staging path with this proposal)

Pros:
1. stageinfo file stored on the node filesystem and not inside the PV mount point. So we don't mass with customer volume data and that way we can also support RO mount (because the staging info file is not storing on the PV it self).
2. Only one mount point on the host, which is simpler.
3. Less idempotancy issues because nodeunstage node will delete the stage info file at the end of the nodeunstage method (without risking of loosing this info file).

Cons:
- Added mount for checking inside the nodestage because i wanted to use k8s mounter tool FormatAndMount, so after success we unmount it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ibm-block-csi-driver/43)
<!-- Reviewable:end -->
