### PR TITLE
Feature/shiny UBI images for CSI plugin

### DIFF
--- a/Dockerfile-csi-controller
+++ b/Dockerfile-csi-controller
@@ -16,13 +16,13 @@ FROM registry.access.redhat.com/ubi8/python-36:1
 MAINTAINER IBM Storage
 
 ###Required Labels
-LABEL name="CSI controller for IBM Block CSI Driver" \
+LABEL name="IBM Block CSI Driver Controller" \
       vendor="IBM" \
       version="1.0.0" \
       release="b1" \
-      summary="The CSI controller component of the IBM block storage CSI driver" \
+      summary="The controller component of the IBM Block CSI driver" \
       description="The IBM block storage CSI driver enables container orchestrators, such as Kubernetes and Openshift, to manage the life-cycle of persistent storage." \
-      io.k8s.display-name="CSI node for IBM Block CSI Driver" \
+      io.k8s.display-name="IBM Block CSI Driver Controller" \
       io.k8s.description="The IBM block storage CSI driver enables container orchestrators, such as Kubernetes and Openshift, to manage the life-cycle of persistent storage." \
       io.openshift.tags=ibm,csi,ibm-block-csi-driver,ibm-block-csi-node
 

--- a/Dockerfile-csi-controller
+++ b/Dockerfile-csi-controller
@@ -13,6 +13,19 @@
 # limitations under the License.
 
 FROM registry.access.redhat.com/ubi8/python-36:1
+MAINTAINER IBM Systems Engineering <TBD>
+
+###Required Labels
+LABEL name="CSI controller for IBM Block CSI Driver"
+LABEL vendor="IBM"
+LABEL version="1.0.0"
+# TODO inject release automatically
+LABEL release="b1" 
+LABEL summary="The CSI controller component of the IBM block storage CSI driver"
+LABEL description="The IBM block storage CSI driver enables container orchestrators, such as Kubernetes and Openshift, to manage the life-cycle of persistent storage."
+LABEL io.k8s.display-name="CSI node for IBM Block CSI Driver"
+LABEL io.k8s.description="The IBM block storage CSI driver enables container orchestrators, such as Kubernetes and Openshift, to manage the life-cycle of persistent storage."
+LABEL io.openshift.tags=ibm,csi,ibm-block-csi-driver,ibm-block-csi-node
 
 COPY controller/requirements.txt /driver/controller/
 RUN pip3 install --upgrade pip==19.1.1
@@ -20,6 +33,7 @@ RUN pip3 install -r /driver/controller/requirements.txt
 
 COPY ./common /driver/common
 COPY ./controller /driver/controller
+#COPY ./image_license /licenses   # TODO need to add relevant license before GA
 WORKDIR /driver
 ENV PYTHONPATH=/driver
 

--- a/Dockerfile-csi-controller
+++ b/Dockerfile-csi-controller
@@ -12,22 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM centos:7
-RUN yum --enablerepo=extras -y install epel-release && yum -y install python36-pip
+FROM registry.access.redhat.com/ubi8/python-36:1
 
 COPY controller/requirements.txt /driver/controller/
 RUN pip3 install --upgrade pip==19.1.1
 RUN pip3 install -r /driver/controller/requirements.txt
 
-
 COPY ./common /driver/common
 COPY ./controller /driver/controller
-RUN groupadd -g 9999 appuser && \
-    useradd -r -u 9999 -g appuser appuser
-RUN chown -R appuser:appuser /driver
-USER appuser
 WORKDIR /driver
 ENV PYTHONPATH=/driver
+
+# Note, UBI runs with app-user by default.
 
 ENTRYPOINT ["/driver/controller/scripts/entrypoint.sh"]
 

--- a/Dockerfile-csi-controller
+++ b/Dockerfile-csi-controller
@@ -13,19 +13,18 @@
 # limitations under the License.
 
 FROM registry.access.redhat.com/ubi8/python-36:1
-MAINTAINER IBM Systems Engineering <TBD>
+MAINTAINER IBM Storage
 
 ###Required Labels
-LABEL name="CSI controller for IBM Block CSI Driver"
-LABEL vendor="IBM"
-LABEL version="1.0.0"
-# TODO inject release automatically
-LABEL release="b1" 
-LABEL summary="The CSI controller component of the IBM block storage CSI driver"
-LABEL description="The IBM block storage CSI driver enables container orchestrators, such as Kubernetes and Openshift, to manage the life-cycle of persistent storage."
-LABEL io.k8s.display-name="CSI node for IBM Block CSI Driver"
-LABEL io.k8s.description="The IBM block storage CSI driver enables container orchestrators, such as Kubernetes and Openshift, to manage the life-cycle of persistent storage."
-LABEL io.openshift.tags=ibm,csi,ibm-block-csi-driver,ibm-block-csi-node
+LABEL name="CSI controller for IBM Block CSI Driver" \
+      vendor="IBM" \
+      version="1.0.0" \
+      release="b1" \
+      summary="The CSI controller component of the IBM block storage CSI driver" \
+      description="The IBM block storage CSI driver enables container orchestrators, such as Kubernetes and Openshift, to manage the life-cycle of persistent storage." \
+      io.k8s.display-name="CSI node for IBM Block CSI Driver" \
+      io.k8s.description="The IBM block storage CSI driver enables container orchestrators, such as Kubernetes and Openshift, to manage the life-cycle of persistent storage." \
+      io.openshift.tags=ibm,csi,ibm-block-csi-driver,ibm-block-csi-node
 
 COPY controller/requirements.txt /driver/controller/
 RUN pip3 install --upgrade pip==19.1.1
@@ -33,7 +32,8 @@ RUN pip3 install -r /driver/controller/requirements.txt
 
 COPY ./common /driver/common
 COPY ./controller /driver/controller
-#COPY ./image_license /licenses   # TODO need to add relevant license before GA
+COPY ./LICENSE /licenses/
+
 WORKDIR /driver
 ENV PYTHONPATH=/driver
 

--- a/Dockerfile-csi-node
+++ b/Dockerfile-csi-node
@@ -30,13 +30,13 @@ RUN make ibm-block-csi-driver
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0
 MAINTAINER IBM Storage
 
-LABEL name="CSI node for IBM Block CSI Driver" \
+LABEL name="IBM Block CSI Driver Node" \
       vendor="IBM" \
       version="1.0.0" \
       release="b1" \
-      summary="The CSI node component of the IBM block storage CSI driver" \
+      summary="The node component of the IBM Block CSI Driver" \
       description="The IBM block storage CSI driver enables container orchestrators, such as Kubernetes and Openshift, to manage the life-cycle of persistent storage." \
-      io.k8s.display-name="CSI node for IBM Block CSI Driver" \
+      io.k8s.display-name="IBM Block CSI Driver Node" \
       io.k8s.description="The IBM block storage CSI driver enables container orchestrators, such as Kubernetes and Openshift, to manage the life-cycle of persistent storage." \
       io.openshift.tags=ibm,csi,ibm-block-csi-driver,ibm-block-csi-node
 

--- a/Dockerfile-csi-node
+++ b/Dockerfile-csi-node
@@ -27,7 +27,7 @@ COPY . .
 RUN make ibm-block-csi-driver
 
 # Final stage
-FROM registry.access.redhat.com/ubi8/ubi:8.0
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0
 WORKDIR /root
 COPY --from=builder /go/src/github.com/ibm/ibm-block-csi-driver/common/config.yaml .
 COPY --from=builder /go/src/github.com/ibm/ibm-block-csi-driver/bin/ibm-block-csi-node-driver .

--- a/Dockerfile-csi-node
+++ b/Dockerfile-csi-node
@@ -28,23 +28,22 @@ RUN make ibm-block-csi-driver
 
 # Final stage
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0
-MAINTAINER IBM Systems Engineering <TBD>
+MAINTAINER IBM Storage
 
-###Required Labels
-LABEL name="CSI node for IBM Block CSI Driver"
-LABEL vendor="IBM"
-LABEL version="1.0.0"
-# TODO inject release automatically
-LABEL release="b1"
-LABEL summary="The CSI node component of the IBM block storage CSI driver"
-LABEL description="The IBM block storage CSI driver enables container orchestrators, such as Kubernetes and Openshift, to manage the life-cycle of persistent storage."
-LABEL io.k8s.display-name= "CSI node for IBM Block CSI Driver"
-LABEL io.k8s.description="The IBM block storage CSI driver enables container orchestrators, such as Kubernetes and Openshift, to manage the life-cycle of persistent storage."
-LABEL io.openshift.tags=ibm,csi,ibm-block-csi-driver,ibm-block-csi-node
+LABEL name="CSI node for IBM Block CSI Driver" \
+      vendor="IBM" \
+      version="1.0.0" \
+      release="b1" \
+      summary="The CSI node component of the IBM block storage CSI driver" \
+      description="The IBM block storage CSI driver enables container orchestrators, such as Kubernetes and Openshift, to manage the life-cycle of persistent storage." \
+      io.k8s.display-name="CSI node for IBM Block CSI Driver" \
+      io.k8s.description="The IBM block storage CSI driver enables container orchestrators, such as Kubernetes and Openshift, to manage the life-cycle of persistent storage." \
+      io.openshift.tags=ibm,csi,ibm-block-csi-driver,ibm-block-csi-node
 
 WORKDIR /root
 COPY --from=builder /go/src/github.com/ibm/ibm-block-csi-driver/common/config.yaml .
 COPY --from=builder /go/src/github.com/ibm/ibm-block-csi-driver/bin/ibm-block-csi-node-driver .
+COPY ./LICENSE /licenses/
 
 RUN mkdir /chroot
 ADD chroot-host-wrapper.sh /chroot

--- a/Dockerfile-csi-node
+++ b/Dockerfile-csi-node
@@ -27,7 +27,7 @@ COPY . .
 RUN make ibm-block-csi-driver
 
 # Final stage
-FROM centos:7
+FROM registry.access.redhat.com/ubi8/ubi:8.0
 WORKDIR /root
 COPY --from=builder /go/src/github.com/ibm/ibm-block-csi-driver/common/config.yaml .
 COPY --from=builder /go/src/github.com/ibm/ibm-block-csi-driver/bin/ibm-block-csi-node-driver .

--- a/Dockerfile-csi-node
+++ b/Dockerfile-csi-node
@@ -28,6 +28,20 @@ RUN make ibm-block-csi-driver
 
 # Final stage
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0
+MAINTAINER IBM Systems Engineering <TBD>
+
+###Required Labels
+LABEL name="CSI node for IBM Block CSI Driver"
+LABEL vendor="IBM"
+LABEL version="1.0.0"
+# TODO inject release automatically
+LABEL release="b1"
+LABEL summary="The CSI node component of the IBM block storage CSI driver"
+LABEL description="The IBM block storage CSI driver enables container orchestrators, such as Kubernetes and Openshift, to manage the life-cycle of persistent storage."
+LABEL io.k8s.display-name= "CSI node for IBM Block CSI Driver"
+LABEL io.k8s.description="The IBM block storage CSI driver enables container orchestrators, such as Kubernetes and Openshift, to manage the life-cycle of persistent storage."
+LABEL io.openshift.tags=ibm,csi,ibm-block-csi-driver,ibm-block-csi-node
+
 WORKDIR /root
 COPY --from=builder /go/src/github.com/ibm/ibm-block-csi-driver/common/config.yaml .
 COPY --from=builder /go/src/github.com/ibm/ibm-block-csi-driver/bin/ibm-block-csi-node-driver .


### PR DESCRIPTION
## Description
Moving to the shiny UBI base images instead of `centos7`, which is one more step to become  Container [Certification](https://redhat-connect.gitbook.io/partner-guide-for-red-hat-openshift-and-container/certify-your-application/containers-with-red-hat-universal-base-image-ubi) for Redhat.

[UBI](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html/getting_started_with_containers/using_red_hat_universal_base_images_standard_minimal_and_runtimes) is the new Redhat\IBM `thin` base image for containers, many advantages for using UBI, one of them is a small footprint (just 101MB).
So good bye Alpine(and Centos), welcome UBI base image ;-)

## **IBM csi node**  
New base image is `registry.access.redhat.com/ubi8/ubi-minimal:8.0`.
Why ubi-minimal?  because CSI node doesn't need much inside (the mount\mkfs and other utils we levarage the worker nodes, so nothing special inside the container).

## **IBM csi controller** 
New base image is `registry.access.redhat.com/ubi8/python-36:1`.
Why ubi8/python-36?  because its already include python3 and pip3.


## RedHat certification docker image alignments:
- Adding the following labels to the dockerfiles:
     name, vendor, version, release, summary, description +
     In addition Openshift specific labels: io.k8s.display-name, io.k8s.description, io.openshift.tags
- Add the project license into /licenses/LICENSE of the images.
- TBD - how to set user\group in this ubi python, open question [here](https://github.com/RHC4TP/starter/issues/2).



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ibm-block-csi-driver/55)
<!-- Reviewable:end -->