### PR TITLE
Improvement/rename driver and add labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,21 @@ daemonset.apps/ibm-block-csi-node created
 Verify the driver is running. (Make sure the csi-controller pod status is Running):
 
 ```sh
+
+$> kubectl get all -n kube-system  -l csi
+NAME                             READY   STATUS    RESTARTS   AGE
+pod/ibm-block-csi-controller-0   5/5     Running   0          9m36s
+pod/ibm-block-csi-node-jvmvh     3/3     Running   0          9m36s
+pod/ibm-block-csi-node-tsppw     3/3     Running   0          9m36s
+
+NAME                                DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
+daemonset.apps/ibm-block-csi-node   2         2         2       2            2           <none>          9m36s
+
+NAME                                        READY   AGE
+statefulset.apps/ibm-block-csi-controller   1/1     9m36s
+
+###### One can also use the following labels: app=ibm-block-csi-node, app=ibm-block-csi-controller, csi=ibm or product=ibm-block-csi-driver 
+
 $> kubectl get -n kube-system pod --selector=app=ibm-block-csi-controller
 NAME                         READY   STATUS    RESTARTS   AGE
 ibm-block-csi-controller-0   5/5     Running   0          10m
@@ -250,7 +265,7 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: gold
-provisioner: ibm-block-csi-driver
+provisioner: block.csi.ibm.com
 parameters:
   SpaceEfficiency: <VALUE>   # Values applicable for Storewize are: Thin, Compressed, or Deduplicated
   pool: <VALUE_POOL_NAME>
@@ -312,7 +327,7 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: gold
-provisioner: ibm-block-csi-driver
+provisioner: block.csi.ibm.com
 parameters:
   pool: gold
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # IBM block storage CSI driver 
 
-The IBM block storage CSI driver enables container orchestrators, such as Kubernetes and Openshift, to manage the life-cycle of persistent storage.
+The IBM block storage CSI driver enables container orchestrators, such as Kubernetes and OpenShift, to manage the life-cycle of persistent storage.
 
 Supported container platforms:
-  - Openshift v4.1
+  - OpenShift v4.1
   - Kubernetes v1.13
 
 Supported IBM storage systems:

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ daemonset.apps/ibm-block-csi-node   2         2         2       2            2  
 NAME                                        READY   AGE
 statefulset.apps/ibm-block-csi-controller   1/1     9m36s
 
-###### One can also use the following labels: app=ibm-block-csi-node, app=ibm-block-csi-controller, csi=ibm or product=ibm-block-csi-driver 
+###### The following labels can also be used: app=ibm-block-csi-node, app=ibm-block-csi-controller, csi=ibm or product=ibm-block-csi-driver.
 
 $> kubectl get -n kube-system pod --selector=app=ibm-block-csi-controller
 NAME                         READY   STATUS    RESTARTS   AGE

--- a/common/config.yaml
+++ b/common/config.yaml
@@ -1,5 +1,5 @@
 identity:
-   name: ibm-block-csi-driver
+   name: block.csi.ibm.com
    version: 1.0.0
    capabilities: 
       - CONTROLLER_SERVICE

--- a/deploy/kubernetes/examples/demo-storageclass-gold-A9000R.yaml
+++ b/deploy/kubernetes/examples/demo-storageclass-gold-A9000R.yaml
@@ -6,7 +6,7 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: gold
-provisioner: ibm-block-csi-driver
+provisioner: block.csi.ibm.com
 parameters:
   pool: gold
 

--- a/deploy/kubernetes/examples/template-storageclass.yaml
+++ b/deploy/kubernetes/examples/template-storageclass.yaml
@@ -7,7 +7,7 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: <VALUE_NAME>
-provisioner: ibm-block-csi-driver
+provisioner: block.csi.ibm.com
 parameters:
   #capabilities:                               # Optional.
   #  SpaceEfficiency=<VALUE>

--- a/deploy/kubernetes/v1.13/ibm-block-csi-driver.yaml
+++ b/deploy/kubernetes/v1.13/ibm-block-csi-driver.yaml
@@ -412,7 +412,7 @@ spec:
             - name: sys-dir
               mountPath: /sys
             - name: host-dir
-              mountPath: /host  # Mapping the root of the host into "/host" inside the container.
+              mountPath: /host  # Maps the host root into "/host", inside the container.
               mountPropagation: "Bidirectional"
 
           ports:

--- a/deploy/kubernetes/v1.13/ibm-block-csi-driver.yaml
+++ b/deploy/kubernetes/v1.13/ibm-block-csi-driver.yaml
@@ -24,6 +24,9 @@ kind: ServiceAccount
 metadata:
   name: ibm-block-csi-controller-sa
   namespace: kube-system
+  labels:
+    product: ibm-block-csi-driver
+    csi: ibm
 
 ---
 
@@ -32,6 +35,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ibm-block-csi-external-provisioner-role
+  labels:
+    product: ibm-block-csi-driver
+    csi: ibm
+  
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
@@ -69,6 +76,10 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ibm-block-csi-external-provisioner-binding
+  labels:
+    product: ibm-block-csi-driver
+    csi: ibm
+
 subjects:
   - kind: ServiceAccount
     name: ibm-block-csi-controller-sa
@@ -84,6 +95,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ibm-block-csi-external-attacher-role
+  labels:
+    product: ibm-block-csi-driver
+    csi: ibm
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -104,6 +118,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ibm-block-csi-external-attacher-binding
+  labels:
+    product: ibm-block-csi-driver
+    csi: ibm
 subjects:
   - kind: ServiceAccount
     name: ibm-block-csi-controller-sa
@@ -119,6 +136,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ibm-block-csi-cluster-driver-registrar-role
+  labels:
+    product: ibm-block-csi-driver
+    csi: ibm
 rules:
   ## Only needed for k8s 1.13 since it was automatic install the CSIDriver. But for 1.14+ its not available.
   - apiGroups: ["apiextensions.k8s.io"]
@@ -135,6 +155,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ibm-block-csi-cluster-driver-registrar-binding
+  labels:
+    product: ibm-block-csi-driver
+    csi: ibm
 subjects:
   - kind: ServiceAccount
     name: ibm-block-csi-controller-sa
@@ -150,6 +173,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ibm-block-csi-external-snapshotter-role
+  labels:
+    product: ibm-block-csi-driver
+    csi: ibm
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -185,6 +211,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ibm-block-csi-external-snapshotter-binding
+  labels:
+    product: ibm-block-csi-driver
+    csi: ibm
 subjects:
   - kind: ServiceAccount
     name: ibm-block-csi-controller-sa
@@ -202,6 +231,9 @@ apiVersion: apps/v1
 metadata:
   name: ibm-block-csi-controller
   namespace: kube-system
+  labels:
+    product: ibm-block-csi-driver
+    csi: ibm
 spec:
   selector:
     matchLabels:
@@ -212,6 +244,8 @@ spec:
     metadata:
       labels:
         app: ibm-block-csi-controller
+        product: ibm-block-csi-driver
+        csi: ibm
     spec:
       serviceAccount: ibm-block-csi-controller-sa
       containers:
@@ -328,6 +362,9 @@ apiVersion: apps/v1
 metadata:
   name: ibm-block-csi-node
   namespace: kube-system
+  labels:
+    product: ibm-block-csi-driver
+    csi: ibm
 spec:
   selector:
     matchLabels:
@@ -336,6 +373,8 @@ spec:
     metadata:
       labels:
         app: ibm-block-csi-node
+        product: ibm-block-csi-driver
+        csi: ibm
     spec:
       hostNetwork: true
       containers:

--- a/deploy/kubernetes/v1.13/ibm-block-csi-driver.yaml
+++ b/deploy/kubernetes/v1.13/ibm-block-csi-driver.yaml
@@ -439,12 +439,12 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/ibm-block-csi-driver-reg.sock /csi/csi.sock"]
+                command: ["/bin/sh", "-c", "rm -rf /registration/block.csi.ibm.com-reg.sock /csi/csi.sock"]
           env:
             - name: ADDRESS
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
-              value: /var/lib/kubelet/plugins/ibm-block-csi-driver/csi.sock
+              value: /var/lib/kubelet/plugins/block.csi.ibm.com/csi.sock
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -470,7 +470,7 @@ spec:
         ## This volume is where the socket for kubelet->driver communication is done
         - name: socket-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/ibm-block-csi-driver/
+            path: /var/lib/kubelet/plugins/block.csi.ibm.com/
             type: DirectoryOrCreate
 
         ## This volume is where the node-driver-registrar registers the plugin with kubelet

--- a/deploy/kubernetes/v1.14/ibm-block-csi-driver.yaml
+++ b/deploy/kubernetes/v1.14/ibm-block-csi-driver.yaml
@@ -24,6 +24,9 @@ kind: ServiceAccount
 metadata:
   name: ibm-block-csi-controller-sa
   namespace: kube-system
+  labels:
+    product: ibm-block-csi-driver
+    csi: ibm
 
 ---
 
@@ -32,6 +35,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ibm-block-csi-external-provisioner-role
+  labels:
+    product: ibm-block-csi-driver
+    csi: ibm
+  
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
@@ -69,6 +76,10 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ibm-block-csi-external-provisioner-binding
+  labels:
+    product: ibm-block-csi-driver
+    csi: ibm
+
 subjects:
   - kind: ServiceAccount
     name: ibm-block-csi-controller-sa
@@ -84,6 +95,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ibm-block-csi-external-attacher-role
+  labels:
+    product: ibm-block-csi-driver
+    csi: ibm
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -104,6 +118,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ibm-block-csi-external-attacher-binding
+  labels:
+    product: ibm-block-csi-driver
+    csi: ibm
 subjects:
   - kind: ServiceAccount
     name: ibm-block-csi-controller-sa
@@ -119,6 +136,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ibm-block-csi-cluster-driver-registrar-role
+  labels:
+    product: ibm-block-csi-driver
+    csi: ibm
 rules:
   - apiGroups: ["csi.storage.k8s.io"]
     resources: ["csidrivers"]
@@ -130,6 +150,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ibm-block-csi-cluster-driver-registrar-binding
+  labels:
+    product: ibm-block-csi-driver
+    csi: ibm
 subjects:
   - kind: ServiceAccount
     name: ibm-block-csi-controller-sa
@@ -145,6 +168,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ibm-block-csi-external-snapshotter-role
+  labels:
+    product: ibm-block-csi-driver
+    csi: ibm
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -180,6 +206,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ibm-block-csi-external-snapshotter-binding
+  labels:
+    product: ibm-block-csi-driver
+    csi: ibm
 subjects:
   - kind: ServiceAccount
     name: ibm-block-csi-controller-sa
@@ -193,17 +222,25 @@ roleRef:
 
 ## CSI Controller Service statefulset
 kind: StatefulSet
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: ibm-block-csi-controller
   namespace: kube-system
+  labels:
+    product: ibm-block-csi-driver
+    csi: ibm
 spec:
+  selector:
+    matchLabels:
+      app: ibm-block-csi-controller
   serviceName: ibm-block-csi-controller
   replicas: 1
   template:
     metadata:
       labels:
         app: ibm-block-csi-controller
+        product: ibm-block-csi-driver
+        csi: ibm
     spec:
       serviceAccount: ibm-block-csi-controller-sa
       containers:
@@ -317,10 +354,13 @@ spec:
 
 # CSI Node Service Deamonset
 kind: DaemonSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: ibm-block-csi-node
   namespace: kube-system
+  labels:
+    product: ibm-block-csi-driver
+    csi: ibm
 spec:
   selector:
     matchLabels:
@@ -329,6 +369,8 @@ spec:
     metadata:
       labels:
         app: ibm-block-csi-node
+        product: ibm-block-csi-driver
+        csi: ibm
     spec:
       hostNetwork: true
       containers:
@@ -339,7 +381,8 @@ spec:
           imagePullPolicy: "IfNotPresent"
           args:
             - --csi-endpoint=$(CSI_ENDPOINT)
-            #- --hostname=$(KUBE_NODE_NAME)
+            - --hostname=$(KUBE_NODE_NAME)
+            - --config-file-path=./config.yaml
             - --loglevel=$(CSI_LOGLEVEL)
           env:
             - name: CSI_ENDPOINT
@@ -364,6 +407,10 @@ spec:
               mountPath: /etc/iscsi
             - name: sys-dir
               mountPath: /sys
+            - name: host-dir
+              mountPath: /host  # Mapping the root of the host into "/host" inside the container.
+              mountPropagation: "Bidirectional"
+
           ports:
             - name: healthz
               containerPort: 9808
@@ -388,12 +435,12 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/ibm-block-csi-driver-reg.sock /csi/csi.sock"]
+                command: ["/bin/sh", "-c", "rm -rf /registration/block.csi.ibm.com-reg.sock /csi/csi.sock"]
           env:
             - name: ADDRESS
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
-              value: /var/lib/kubelet/plugins/ibm-block-csi-driver/csi.sock
+              value: /var/lib/kubelet/plugins/block.csi.ibm.com/csi.sock
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -404,7 +451,7 @@ spec:
           image: quay.io/k8scsi/livenessprobe:v1.1.0  # TODO v1.1.0 is for k8s 1.13+, but v1.0.2 was the first k8s 1.13 version.
           args:
             - --csi-address=/csi/csi.sock
-            - --connection-timeout=3s   # TODO this line is deprecated from v1.1.0. So if exist its ignore it.
+            - --connection-timeout=3s   # NOTE: this line is deprecated from v1.1.0. So if exist its ignore it.
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -419,7 +466,7 @@ spec:
         ## This volume is where the socket for kubelet->driver communication is done
         - name: socket-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/ibm-block-csi-driver/
+            path: /var/lib/kubelet/plugins/block.csi.ibm.com/
             type: DirectoryOrCreate
 
         ## This volume is where the node-driver-registrar registers the plugin with kubelet
@@ -445,6 +492,10 @@ spec:
             path: /sys
             type: Directory
 
+        - name: host-dir
+          hostPath:
+            path: /
+            type: Directory
 
 
 ## The below CSIDriver object is required to define (k8s 1.14 its still needed to be added due to redesign -> https://kubernetes-csi.github.io/docs/cluster-driver-registrar.html)

--- a/deploy/kubernetes/v1.14/ibm-block-csi-driver.yaml
+++ b/deploy/kubernetes/v1.14/ibm-block-csi-driver.yaml
@@ -408,7 +408,7 @@ spec:
             - name: sys-dir
               mountPath: /sys
             - name: host-dir
-              mountPath: /host  # Mapping the root of the host into "/host" inside the container.
+              mountPath: /host  # Maps the host root into "/host", inside the container.
               mountPropagation: "Bidirectional"
 
           ports:


### PR DESCRIPTION
1. Rename to driver CSI dotted name from ibm-block-csi-driver -> block.csi.ibm.com, to be comply with CSI naming conversion.

2. Add helpful labels: `csi=ibm` and `product: ibm-block-csi-driver`.
   The csi=ibm helps for quickly review the csi by `$> kubectl get all -n kube-system  -l csi`




<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ibm-block-csi-driver/58)
<!-- Reviewable:end -->
