### PR TITLE
Fix/CSI-485 works without /etc/iscsi directory

### DIFF
--- a/deploy/kubernetes/v1.13/ibm-block-csi-driver.yaml
+++ b/deploy/kubernetes/v1.13/ibm-block-csi-driver.yaml
@@ -407,8 +407,6 @@ spec:
 
             - name: device-dir
               mountPath: /dev
-            - name: iscsi-dir
-              mountPath: /etc/iscsi
             - name: sys-dir
               mountPath: /sys
             - name: host-dir
@@ -483,12 +481,6 @@ spec:
         - name: device-dir
           hostPath:
             path: /dev
-            type: Directory
-
-        ## To retrieve the IQN for the GetNodeInfo API
-        - name: iscsi-dir
-          hostPath:
-            path: /etc/iscsi/
             type: Directory
 
         - name: sys-dir

--- a/deploy/kubernetes/v1.14/ibm-block-csi-driver.yaml
+++ b/deploy/kubernetes/v1.14/ibm-block-csi-driver.yaml
@@ -403,8 +403,6 @@ spec:
 
             - name: device-dir
               mountPath: /dev
-            - name: iscsi-dir
-              mountPath: /etc/iscsi
             - name: sys-dir
               mountPath: /sys
             - name: host-dir
@@ -479,12 +477,6 @@ spec:
         - name: device-dir
           hostPath:
             path: /dev
-            type: Directory
-
-        ## To retrieve the IQN for the GetNodeInfo API
-        - name: iscsi-dir
-          hostPath:
-            path: /etc/iscsi/
             type: Directory
 
         - name: sys-dir

--- a/node/pkg/driver/node.go
+++ b/node/pkg/driver/node.go
@@ -56,7 +56,7 @@ var (
 		// TODO add fc \ nvme later on
 	}
 
-	IscsiFullPath = "/etc/iscsi/initiatorname.iscsi"
+	IscsiFullPath = "/host/etc/iscsi/initiatorname.iscsi"
 )
 
 const (

--- a/node/pkg/driver/node_utils_test.go
+++ b/node/pkg/driver/node_utils_test.go
@@ -71,7 +71,7 @@ func TestParseIscsiInitiators(t *testing.T) {
 
 				defer func(){
 					os.Remove(tmpFile.Name())
-					driver.IscsiFullPath = "/etc/iscsi/initiatorname.iscsi"
+					driver.IscsiFullPath = "/host/etc/iscsi/initiatorname.iscsi"
 				}()
 
 				fmt.Println("Created File: " + tmpFile.Name())

--- a/scripts/ci/run_node_server_for_csi_test.sh
+++ b/scripts/ci/run_node_server_for_csi_test.sh
@@ -9,5 +9,5 @@ chmod 777 /tmp/k8s_dir
 
 [ $# -ne 1 ] && { echo "Usage $0 : container_name"  ; exit 1; }
 
-docker build -f Dockerfile-csi-node -t csi-node . &&  docker run -v /etc/iscsi:/etc/iscsi -v /tmp/k8s_dir:/tmp/k8s_dir:rw -d --rm --name $1  csi-node --csi-endpoint unix://tmp/k8s_dir/nodecsi --hostname=`hostname` --config-file-path=./config.yaml
+docker build -f Dockerfile-csi-node -t csi-node . &&  docker run -v /etc/iscsi:/host/etc/iscsi -v /tmp/k8s_dir:/tmp/k8s_dir:rw -d --rm --name $1  csi-node --csi-endpoint unix://tmp/k8s_dir/nodecsi --hostname=`hostname` --config-file-path=./config.yaml
 


### PR DESCRIPTION
Ran tested the plugin on FC environemnt without any iscsi service on the worker nodes (which is the common use case in Fc env). And he find an issue that the csi node is failing due to missing /etc/iscsi directory.

So this PR fix 
Before this PR /etc/iscsi hostpath was specified in the yaml. So I removed this specific hostpath from the yaml and fixed the code to take /etc/iscsi from the /host/etc/iscsi which is already the hostpath of the worker node. So there is no really need to specify also /etc/iscsi in the yaml if we already have hostpath / inside csi node in /host directory (reminder - csi node requires the / of the worker node because it discover multipath devices inside the csi node container).


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ibm-block-csi-driver/68)
<!-- Reviewable:end -->
