### PR TITLE
Upgrade attacher to 1.2.1 

### DIFF
--- a/deploy/kubernetes/v1.13/ibm-block-csi-driver.yaml
+++ b/deploy/kubernetes/v1.13/ibm-block-csi-driver.yaml
@@ -313,7 +313,7 @@ spec:
 
 
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v1.2.0
+          image: quay.io/k8scsi/csi-attacher:v1.2.1
           imagePullPolicy: "IfNotPresent"
           args:
             - --csi-address=$(ADDRESS)

--- a/deploy/kubernetes/v1.14/ibm-block-csi-driver.yaml
+++ b/deploy/kubernetes/v1.14/ibm-block-csi-driver.yaml
@@ -308,7 +308,7 @@ spec:
 
 
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v1.2.0
+          image: quay.io/k8scsi/csi-attacher:v1.2.1
           imagePullPolicy: "IfNotPresent"
           args:
             - --csi-address=$(ADDRESS)


### PR DESCRIPTION
to get the fix https://github.com/kubernetes-csi/external-attacher/pull/168

https://github.com/kubernetes-csi/external-attacher/pull/168#issuecomment-530803871

related to -> https://github.com/IBM/ibm-block-csi-driver/pull/70

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ibm-block-csi-driver/71)
<!-- Reviewable:end -->
