### PR TITLE
update pysvc version and Dockerfile-csi-controller

### DIFF
--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -3,8 +3,9 @@ grpcio-tools==1.20.1
 protobuf==3.7.1
 pyyaml==5.1
 munch==2.3.2
+paramiko==2.6.0
 
 # A9000 python client
 pyxcli==1.2.1
 # SVC python client
-pysvc==1.1.0
+pysvc==1.1.1


### PR DESCRIPTION
1. upgrade pysvc from 1.1.0 to 1.1.1 since the paramiko has been upgraded to 2.6.0, the new pysvc package need to upload to pypi server, but pypi doesn;t allow to reuse name for the package, so update pysvc version from 1.1.0 to 1.1.1
2. add paramiko==2.6.0 in requirements.txt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ibm-block-csi-driver/74)
<!-- Reviewable:end -->
