### PR TITLE
Task/csi 499 codescan

### DIFF
--- a/Dockerfile-csi-controller-code-scan
+++ b/Dockerfile-csi-controller-code-scan
@@ -17,26 +17,16 @@ FROM python:3.6.9
 RUN pip3 install bandit
 
 COPY controller /controller
+COPY scripts/csi_controller_code_scan_entrypoint.sh entrypoint.sh
 RUN mkdir /results
 
 RUN groupadd -g 9999 appuser && \
     useradd -r -u 9999 -g appuser appuser
 
-RUN chown -R appuser:appuser /controller /results
-
-RUN echo '#!/bin/bash \n\
-    if [ -z "$SKIPS" ]\n\
-    then\n\
-        /usr/local/bin/bandit -ll -f xml -o /results/bandit_result.xml -r /controller\n\
-    else\n\
-        /usr/local/bin/bandit -ll -s ${SKIPS} -f xml -o /results/bandit_result.xml -r /controller\n\
-    fi\n\
-    ' > ./entrypoint.sh && \
-    chmod +x ./entrypoint.sh
+RUN chown -R appuser:appuser /controller /results entrypoint.sh
 
 USER appuser
 WORKDIR .
 
 ENTRYPOINT ["./entrypoint.sh"]
-
 

--- a/Dockerfile-csi-controller-code-scan
+++ b/Dockerfile-csi-controller-code-scan
@@ -24,7 +24,14 @@ RUN groupadd -g 9999 appuser && \
 
 RUN chown -R appuser:appuser /controller /results
 
-RUN echo '#!/bin/bash \n/usr/local/bin/bandit -s ${SKIPS} -f xml -o /results/bandit_result.xml -r /controller' > ./entrypoint.sh && \
+RUN echo '#!/bin/bash \n\
+    if [ -z "$SKIPS" ]\n\
+    then\n\
+        /usr/local/bin/bandit -ll -f xml -o /results/bandit_result.xml -r /controller\n\
+    else\n\
+        /usr/local/bin/bandit -ll -s ${SKIPS} -f xml -o /results/bandit_result.xml -r /controller\n\
+    fi\n\
+    ' > ./entrypoint.sh && \
     chmod +x ./entrypoint.sh
 
 USER appuser

--- a/Dockerfile-csi-controller-code-scan
+++ b/Dockerfile-csi-controller-code-scan
@@ -1,0 +1,35 @@
+# Copyright IBM Corporation 2019.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:3.6.9
+
+RUN pip3 install bandit
+
+COPY controller /controller
+RUN mkdir /results
+
+RUN groupadd -g 9999 appuser && \
+    useradd -r -u 9999 -g appuser appuser
+
+RUN chown -R appuser:appuser /controller /results
+
+RUN echo '#!/bin/bash \n/usr/local/bin/bandit -s ${SKIPS} -f xml -o /results/bandit_result.xml -r /controller' > ./entrypoint.sh && \
+    chmod +x ./entrypoint.sh
+
+USER appuser
+WORKDIR .
+
+ENTRYPOINT ["./entrypoint.sh"]
+
+

--- a/Dockerfile-csi-node-code-scan
+++ b/Dockerfile-csi-node-code-scan
@@ -12,24 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.6.9
+FROM golang:1.11
 
-RUN pip3 install bandit
-
-COPY controller /controller
+COPY node /node
 RUN mkdir /results
 
 RUN groupadd -g 9999 appuser && \
     useradd -r -u 9999 -g appuser appuser
-
-RUN chown -R appuser:appuser /controller /results
+RUN chown -R appuser:appuser /node /results
+RUN go get github.com/securego/gosec/cmd/gosec
 
 RUN echo '#!/bin/bash \n\
-    if [ -z "$SKIPS" ]\n\
+    if [ -z "$EXCLUDE" ]\n\
     then\n\
-        /usr/local/bin/bandit -ll -f xml -o /results/bandit_result.xml -r /controller\n\
+        gosec -fmt=junit-xml -out /results/gosec_result.xml /node\n\
     else\n\
-        /usr/local/bin/bandit -ll -s ${SKIPS} -f xml -o /results/bandit_result.xml -r /controller\n\
+        gosec -exclude=${EXCLUDE} -fmt=junit-xml -out /results/gosec_result.xml /node\n\
     fi\n\
     ' > ./entrypoint.sh && \
     chmod +x ./entrypoint.sh
@@ -38,5 +36,4 @@ USER appuser
 WORKDIR .
 
 ENTRYPOINT ["./entrypoint.sh"]
-
 

--- a/Dockerfile-csi-node-code-scan
+++ b/Dockerfile-csi-node-code-scan
@@ -15,22 +15,14 @@
 FROM golang:1.11
 
 COPY node /node
+COPY scripts/csi_node_code_scan_entrypoint.sh entrypoint.sh
 RUN mkdir /results
 
 RUN groupadd -g 9999 appuser && \
     useradd -r -u 9999 -g appuser appuser
-RUN chown -R appuser:appuser /node /results
+RUN chown -R appuser:appuser /node /results entrypoint.sh
 RUN go get github.com/securego/gosec/cmd/gosec
 
-RUN echo '#!/bin/bash \n\
-    if [ -z "$EXCLUDE" ]\n\
-    then\n\
-        gosec -fmt=junit-xml -out /results/gosec_result.xml /node\n\
-    else\n\
-        gosec -exclude=${EXCLUDE} -fmt=junit-xml -out /results/gosec_result.xml /node\n\
-    fi\n\
-    ' > ./entrypoint.sh && \
-    chmod +x ./entrypoint.sh
 
 USER appuser
 WORKDIR .

--- a/scripts/ci/jenkins_pipeline_csi
+++ b/scripts/ci/jenkins_pipeline_csi
@@ -20,6 +20,12 @@ pipeline {
           
             }
         }
+        stage ('CSI-controller: security code scanning') {
+            steps {
+                sh 'mkdir -p build/reports && chmod 777 build/reports'
+                sh './scripts/run_csi_code_scan.sh'
+            }
+        }
         stage ('CSI-node: go Unit testing') {
             steps {
                 sh 'mkdir -p build/reports && chmod 777 build/reports'

--- a/scripts/ci/jenkins_pipeline_csi
+++ b/scripts/ci/jenkins_pipeline_csi
@@ -20,7 +20,7 @@ pipeline {
           
             }
         }
-        stage ('CSI-controller: security code scanning') {
+        stage ('CSI controller and node: security code scanning') {
             steps {
                 sh 'mkdir -p build/reports && chmod 777 build/reports'
                 sh './scripts/run_csi_code_scan.sh'

--- a/scripts/csi_controller_code_scan_entrypoint.sh
+++ b/scripts/csi_controller_code_scan_entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ -z "$SKIPS" ]
+then
+    /usr/local/bin/bandit -ll -f xml -o /results/bandit_result.xml -r /controller
+else
+    /usr/local/bin/bandit -ll -s ${SKIPS} -f xml -o /results/bandit_result.xml -r /controller
+fi
+

--- a/scripts/csi_node_code_scan_entrypoint.sh
+++ b/scripts/csi_node_code_scan_entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ -z "$EXCLUDE" ]
+then
+    gosec -fmt=junit-xml -out /results/gosec_result.xml /node
+else
+    gosec -exclude=${EXCLUDE} -fmt=junit-xml -out /results/gosec_result.xml /node
+fi
+

--- a/scripts/run_csi_code_scan.sh
+++ b/scripts/run_csi_code_scan.sh
@@ -1,12 +1,21 @@
 #!/bin/bash -x
 
-if [ -z "BANDIT_SKIPS" ]
+if [ -z "$BANDIT_SKIPS" ]
 then
     export BANDIT_SKIPS=""
 fi
+
+if [ -z "$GOSEC_EXCLUDE" ]
+then
+    export GOSEC_EXCLUDE=""
+fi
+
 
 export OUTPUT_PATH="`pwd`/build/reports"
 
 docker build -f Dockerfile-csi-controller-code-scan -t csi-controller-code-scan . && \
 docker run --rm -t -v ${OUTPUT_PATH}:/results -e SKIPS=${BANDIT_SKIPS} csi-controller-code-scan
+
+docker build -f Dockerfile-csi-node-code-scan -t csi-node-code-scan . && \
+docker run --rm -t -v ${OUTPUT_PATH}:/results -e EXCLUDE=${GOSEC_EXCLUDE} csi-node-code-scan
 

--- a/scripts/run_csi_code_scan.sh
+++ b/scripts/run_csi_code_scan.sh
@@ -1,8 +1,12 @@
 #!/bin/bash -x
 
-export SKIPS="B703"
+if [ -z "BANDIT_SKIPS" ]
+then
+    export BANDIT_SKIPS=""
+fi
+
 export OUTPUT_PATH="`pwd`/build/reports"
 
 docker build -f Dockerfile-csi-controller-code-scan -t csi-controller-code-scan . && \
-docker run --rm -t -v ${OUTPUT_PATH}:/results -e SKIPS=${SKIPS} csi-controller-code-scan
+docker run --rm -t -v ${OUTPUT_PATH}:/results -e SKIPS=${BANDIT_SKIPS} csi-controller-code-scan
 

--- a/scripts/run_csi_code_scan.sh
+++ b/scripts/run_csi_code_scan.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -x
+
+export SKIPS="B703"
+export OUTPUT_PATH="`pwd`/build/reports"
+
+docker build -f Dockerfile-csi-controller-code-scan -t csi-controller-code-scan . && \
+docker run --rm -t -v ${OUTPUT_PATH}:/results -e SKIPS=${SKIPS} csi-controller-code-scan
+


### PR DESCRIPTION
I have created two Docker images for the code scan:
- Python that is using bandit tool for scanning python code
- Go that is using gosec tool for scanning golang code

I created a script and a pipeline stage to run the scans.

The python is set to display Medium issues and above, excluding one issue which has an open ticket for it

Any failure will fail the build process

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ibm-block-csi-driver/75)
<!-- Reviewable:end -->
