### PR TITLE
refactor methods for device_connectivity_helper_scsigeneric

### DIFF
--- a/node/pkg/driver/device_connectivity/device_connectivity_fc.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_fc.go
@@ -30,12 +30,12 @@ type OsDeviceConnectivityFc struct {
 func NewOsDeviceConnectivityFc(executer executer.ExecuterInterface) OsDeviceConnectivityInterface {
 	return &OsDeviceConnectivityFc{
 		Executer:          executer,
-		HelperScsiGeneric: NewOsDeviceConnectivityHelperScsiGeneric(executer),
+		HelperScsiGeneric: NewOsDeviceConnectivityHelperScsiGeneric(executer, FcRegexpValue, FcHostRexExPath),
 	}
 }
 
 func (r OsDeviceConnectivityFc) RescanDevices(lunId int, arrayIdentifiers []string) error {
-	return r.HelperScsiGeneric.RescanDevices(lunId, arrayIdentifiers, FcRegexpValue, FcHostRexExPath)
+	return r.HelperScsiGeneric.RescanDevices(lunId, arrayIdentifiers)
 }
 
 func (r OsDeviceConnectivityFc) GetMpathDevice(volumeId string, lunId int, arrayIdentifiers []string) (string, error) {

--- a/node/pkg/driver/device_connectivity/device_connectivity_helper_scsigeneric.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_helper_scsigeneric.go
@@ -31,6 +31,18 @@ import (
 	"k8s.io/apimachinery/pkg/util/errors"
 )
 
+const (
+	DevPath                 = "/dev"
+	connectivityTypeOfFc    = "fc"
+	connectivityTypeOfIscsi = "iscsi"
+	IscsiRegexpValue        = "host([0-9]+)"
+	FcRegexpValue           = "rport-([0-9]+)"
+	IscsiTargetPath         = "/dev/disk/by-path/ip*"
+	FcTargetPath            = "/dev/disk/by-path/pci*"
+	FcHostRexExPath         = "/sys/class/fc_remote_ports/rport-*/port_name"
+	IscsiHostRexExPath      = "/sys/class/iscsi_host/host*/device/session*/iscsi_session/session*/targetname"
+)
+
 //go:generate mockgen -destination=../../../mocks/mock_OsDeviceConnectivityHelperScsiGenericInterface.go -package=mocks github.com/ibm/ibm-block-csi-driver/node/pkg/driver/device_connectivity OsDeviceConnectivityHelperScsiGenericInterface
 
 type OsDeviceConnectivityHelperScsiGenericInterface interface {
@@ -52,18 +64,6 @@ type OsDeviceConnectivityHelperScsiGeneric struct {
 
 var (
 	TimeOutMultipathFlashCmd = 4 * 1000
-)
-
-const (
-	DevPath                 = "/dev"
-	connectivityTypeOfFc    = "fc"
-	connectivityTypeOfIscsi = "iscsi"
-	IscsiRegexpValue        = "host([0-9]+)"
-	FcRegexpValue           = "rport-([0-9]+)"
-	IscsiTargetPath         = "/dev/disk/by-path/ip*"
-	FcTargetPath            = "/dev/disk/by-path/pci*"
-	FcHostRexExPath         = "/sys/class/fc_remote_ports/rport-*/port_name"
-	IscsiHostRexExPath      = "/sys/class/iscsi_host/host*/device/session*/iscsi_session/session*/targetname"
 )
 
 func NewOsDeviceConnectivityHelperScsiGeneric(executer executer.ExecuterInterface) OsDeviceConnectivityHelperScsiGenericInterface {
@@ -126,7 +126,7 @@ func (r OsDeviceConnectivityHelperScsiGeneric) RescanDevices(lunId int, arrayIde
 }
 
 func (r OsDeviceConnectivityHelperScsiGeneric) GetMpathDevice(volumeId string, lunId int, arrayIdentifiers []string, connectivityType string, targetPath string) (string, error) {
-	logger.Infof("GetMpathDevice: Found multipath devices for volume : [%s] that relats to lunId=%d, arrayIdentifiers=%s and targetPath=%s", volumeId, lunId, arrayIdentifiers, targetPath)
+	logger.Infof("GetMpathDevice: Found multipath devices for volume : [%s] that relates to lunId=%d, arrayIdentifiers=%s and targetPath=%s", volumeId, lunId, arrayIdentifiers, targetPath)
 
 	if len(arrayIdentifiers) == 0 {
 		e := &ErrorNotFoundArrayIdentifiers{lunId}
@@ -427,7 +427,7 @@ func (o OsDeviceConnectivityHelperGeneric) GetHostsIdByArrayIdentifier(arrayIden
 			} else {
 				hostNumber, err = strconv.Atoi(regexMatch[1])
 				if err != nil {
-					logger.Warningf("Failed to get the host nvumber in: {%v}, try again.", regexMatch[1])
+					logger.Warningf("Failed to get the host number in: {%v}, skip it.", regexMatch[1])
 					continue
 				}
 			}

--- a/node/pkg/driver/device_connectivity/device_connectivity_iscsi.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_iscsi.go
@@ -33,7 +33,7 @@ func NewOsDeviceConnectivityIscsi(executer executer.ExecuterInterface) OsDeviceC
 }
 
 func (r OsDeviceConnectivityIscsi) RescanDevices(lunId int, arrayIdentifiers []string) error {
-	return r.HelperScsiGeneric.RescanDevices(lunId, arrayIdentifiers)
+	return r.HelperScsiGeneric.RescanDevices(lunId, arrayIdentifiers, IscsiRegexpValue, IscsiHostRexExPath)
 }
 
 func (r OsDeviceConnectivityIscsi) GetMpathDevice(volumeId string, lunId int, arrayIdentifiers []string) (string, error) {
@@ -47,7 +47,7 @@ func (r OsDeviceConnectivityIscsi) GetMpathDevice(volumeId string, lunId int, ar
 
 			   Return Value: "dm-X" of the volumeID by using the LunID and the arrayIqn.
 	*/
-	return r.HelperScsiGeneric.GetMpathDevice(volumeId, lunId, arrayIdentifiers, "iscsi")
+	return r.HelperScsiGeneric.GetMpathDevice(volumeId, lunId, arrayIdentifiers, connectivityTypeOfIscsi, IscsiTargetPath)
 }
 
 func (r OsDeviceConnectivityIscsi) FlushMultipathDevice(mpathDevice string) error {

--- a/node/pkg/driver/device_connectivity/device_connectivity_iscsi.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_iscsi.go
@@ -28,12 +28,12 @@ type OsDeviceConnectivityIscsi struct {
 func NewOsDeviceConnectivityIscsi(executer executer.ExecuterInterface) OsDeviceConnectivityInterface {
 	return &OsDeviceConnectivityIscsi{
 		Executer:          executer,
-		HelperScsiGeneric: NewOsDeviceConnectivityHelperScsiGeneric(executer),
+		HelperScsiGeneric: NewOsDeviceConnectivityHelperScsiGeneric(executer, IscsiRegexpValue, IscsiHostRexExPath),
 	}
 }
 
 func (r OsDeviceConnectivityIscsi) RescanDevices(lunId int, arrayIdentifiers []string) error {
-	return r.HelperScsiGeneric.RescanDevices(lunId, arrayIdentifiers, IscsiRegexpValue, IscsiHostRexExPath)
+	return r.HelperScsiGeneric.RescanDevices(lunId, arrayIdentifiers)
 }
 
 func (r OsDeviceConnectivityIscsi) GetMpathDevice(volumeId string, lunId int, arrayIdentifiers []string) (string, error) {


### PR DESCRIPTION
1. Refactor for RescanDevices, GetMpathDevice, GetHostsIdByArrayIdentifier method
2. Use errors.NewAggregate to generate a list errors
3. Refactor for some logs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ibm-block-csi-driver/76)
<!-- Reviewable:end -->
