### PR TITLE
BUG fix - avoid logging the syncMap content + loadorstore (not thread safe)

### DIFF
--- a/node/pkg/driver/sync_lock.go
+++ b/node/pkg/driver/sync_lock.go
@@ -49,11 +49,11 @@ func (s SyncLock) GetSyncMap() *sync.Map {
 
 func (s SyncLock) AddVolumeLock(id string, msg string) error {
 	goid := util.GetGoID()
-	logger.Debugf("Lock for action %s, Try to acquire lock for volume ID=%s (syncMap=%v) goid=%d", msg, id, s.SyncMap, goid)
+	logger.Debugf("Lock for action %s, Try to acquire lock for volume ID=%s goid=%d", msg, id, goid)
 	_, exists := s.SyncMap.Load(id)
 	if !exists {
 		s.SyncMap.Store(id, 0)
-		logger.Debugf("Lock for action %s, Succeed to acquire lock for volume ID=%s (syncMap=%v) goid=%d", msg, id, s.SyncMap, goid)
+		logger.Debugf("Lock for action %s, Succeed to acquire lock for volume ID=%s goid=%d", msg, id, goid)
 		return nil
 	} else {
 		logger.Debugf("Lock for action %s, Lock for volume ID=%s is already in use by other thread. goid=%d", msg, id, goid)
@@ -63,7 +63,7 @@ func (s SyncLock) AddVolumeLock(id string, msg string) error {
 
 func (s SyncLock) RemoveVolumeLock(id string, msg string) {
 	goid := util.GetGoID()
-	logger.Debugf("Lock for action %s, release lock for volume ID=%s (syncMap=%v) goid=%d ", msg, id, s.SyncMap, goid)
+	logger.Debugf("Lock for action %s, release lock for volume ID=%s goid=%d", msg, id, goid)
 
 	_, exists := s.SyncMap.Load(id)
 	if exists {

--- a/node/pkg/driver/sync_lock.go
+++ b/node/pkg/driver/sync_lock.go
@@ -48,9 +48,8 @@ func (s SyncLock) GetSyncMap() *sync.Map {
 
 func (s SyncLock) AddVolumeLock(id string, msg string) error {
 	logger.Debugf("Lock for action %s, Try to acquire lock for volume", msg)
-	_, exists := s.SyncMap.Load(id)
+	_, exists := s.SyncMap.LoadOrStore(id, 0)
 	if !exists {
-		s.SyncMap.Store(id, 0)
 		logger.Debugf("Lock for action %s, Succeed to acquire lock for volume", msg)
 		return nil
 	} else {
@@ -62,10 +61,7 @@ func (s SyncLock) AddVolumeLock(id string, msg string) error {
 func (s SyncLock) RemoveVolumeLock(id string, msg string) {
 	logger.Debugf("Lock for action %s, release lock for volume", msg)
 
-	_, exists := s.SyncMap.Load(id)
-	if exists {
-		s.SyncMap.Delete(id)
-	}
+	s.SyncMap.Delete(id)
 }
 
 /*func (s SyncLock) RemoveVolumeLock(id string, msg string) func() {

--- a/node/pkg/driver/sync_lock.go
+++ b/node/pkg/driver/sync_lock.go
@@ -48,22 +48,20 @@ func (s SyncLock) GetSyncMap() *sync.Map {
 }
 
 func (s SyncLock) AddVolumeLock(id string, msg string) error {
-	goid := util.GetGoID()
-	logger.Debugf("Lock for action %s, Try to acquire lock for volume ID=%s goid=%d", msg, id, goid)
+	logger.Debugf("Lock for action %s, Try to acquire lock for volume", msg)
 	_, exists := s.SyncMap.Load(id)
 	if !exists {
 		s.SyncMap.Store(id, 0)
-		logger.Debugf("Lock for action %s, Succeed to acquire lock for volume ID=%s goid=%d", msg, id, goid)
+		logger.Debugf("Lock for action %s, Succeed to acquire lock for volume", msg)
 		return nil
 	} else {
-		logger.Debugf("Lock for action %s, Lock for volume ID=%s is already in use by other thread. goid=%d", msg, id, goid)
+		logger.Debugf("Lock for action %s, Lock for volume is already in use by other thread", msg)
 		return &VolumeAlreadyProcessingError{id}
 	}
 }
 
 func (s SyncLock) RemoveVolumeLock(id string, msg string) {
-	goid := util.GetGoID()
-	logger.Debugf("Lock for action %s, release lock for volume ID=%s goid=%d", msg, id, goid)
+	logger.Debugf("Lock for action %s, release lock for volume", msg)
 
 	_, exists := s.SyncMap.Load(id)
 	if exists {

--- a/node/pkg/driver/sync_lock.go
+++ b/node/pkg/driver/sync_lock.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 
 	"github.com/ibm/ibm-block-csi-driver/node/logger"
-	"github.com/ibm/ibm-block-csi-driver/node/util"
 )
 
 //go:generate mockgen -destination=../../mocks/mock_sync_lock.go -package=mocks github.com/ibm/ibm-block-csi-driver/node/pkg/driver SyncLockInterface


### PR DESCRIPTION
This PR tries to fix issue [CSI-505](https://jira.xiv.ibm.com/browse/CSI-505).

The problem is that we should not print a sync.Map!!

Although sync.Map is goroutine safe, you must use the methods it exposes. If not, it is not safe. So you can not print a whole sync.Map because it doesn't have such a method to return its conent. If you print the sync.Map directly, all the fields will be printed. It has 4 fields: mu, read, dirty and misses. "dirty" is a map, and it is not safe, that's the root cause we faced: during printing "dirty", some items are removed, and we enconter a "index out of range" error.

We can use sync.Map.Range to get all kvs, but I don't think it is necessary.

In addition this PR contains fix with https://github.com/IBM/ibm-block-csi-driver/pull/80 (see detail in PR #80 )
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ibm-block-csi-driver/79)
<!-- Reviewable:end -->
