### PR TITLE
fix CSI-528

### DIFF
--- a/controller/array_action/array_mediator_svc.py
+++ b/controller/array_action/array_mediator_svc.py
@@ -239,7 +239,9 @@ class SVCArrayMediator(ArrayMediator):
             wwns_value = host_detail.get('WWPN', [])
             if not isinstance(wwns_value, list):
                 wwns_value = [wwns_value, ]
-            if initiators.is_array_iscsi_iqns_match([iscsi_names]):
+            if not isinstance(iscsi_names, list):
+                iscsi_names = [iscsi_names, ]
+            if initiators.is_array_iscsi_iqns_match(iscsi_names):
                 iscsi_host = host_detail.get('name', '')
                 logger.debug("found iscsi iqn in list : {0} for host : "
                              "{1}".format(initiators.iscsi_iqn, iscsi_host))

--- a/controller/array_action/array_mediator_svc.py
+++ b/controller/array_action/array_mediator_svc.py
@@ -240,7 +240,7 @@ class SVCArrayMediator(ArrayMediator):
             if not isinstance(wwns_value, list):
                 wwns_value = [wwns_value, ]
             if not isinstance(iscsi_names, list):
-                iscsi_names = [iscsi_names, ]
+                iscsi_names = [] if len(iscsi_names) == 0 else [iscsi_names]
             if initiators.is_array_iscsi_iqns_match(iscsi_names):
                 iscsi_host = host_detail.get('name', '')
                 logger.debug("found iscsi iqn in list : {0} for host : "

--- a/controller/tests/array_action/svc/array_mediator_svc_test.py
+++ b/controller/tests/array_action/svc/array_mediator_svc_test.py
@@ -269,7 +269,7 @@ class TestArrayMediatorSVC(unittest.TestCase):
         host_munch_ret_1 = Munch({'id': 'host_id_1', 'name': 'test_host_1',
                                   'WWPN': ['abc1']})
         host_munch_ret_2 = Munch({'id': 'host_id_2', 'name': 'test_host_3',
-                                  'iscsi_name': 'iqn.test.2',
+                                  'iscsi_name': ['iqn.test.2'],
                                   'WWPN': ['abc3']})
         host_munch_ret_3 = Munch({'id': 'host_id_3', 'name': 'test_host_3',
                                   'WWPN': ['abc3'],
@@ -280,6 +280,16 @@ class TestArrayMediatorSVC(unittest.TestCase):
         self.svc.client.svcinfo.lshost.side_effect = [ret1, ret2, ret3]
         host, connectivity_type = self.svc.get_host_by_host_identifiers(Initiators(
             'iqn.test.2', ['abcd3']))
+        self.assertEqual('test_host_3', host)
+        self.assertEqual([config.ISCSI_CONNECTIVITY_TYPE], connectivity_type)
+
+        host_munch_ret_4 = Munch({'id': 'host_id_2', 'name': 'test_host_3',
+                                  'iscsi_name': 'iqn.test.2',
+                                  'WWPN': ['abc3']})
+        ret4 = Munch(as_single_element=host_munch_ret_4)
+        self.svc.client.svcinfo.lshost.side_effect = [ret1, ret4, ret3]
+        host, connectivity_type = self.svc.get_host_by_host_identifiers(
+            Initiators('iqn.test.2', ['abcd3']))
         self.assertEqual('test_host_3', host)
         self.assertEqual([config.ISCSI_CONNECTIVITY_TYPE], connectivity_type)
 

--- a/controller/tests/array_action/svc/array_mediator_svc_test.py
+++ b/controller/tests/array_action/svc/array_mediator_svc_test.py
@@ -283,13 +283,39 @@ class TestArrayMediatorSVC(unittest.TestCase):
         self.assertEqual('test_host_3', host)
         self.assertEqual([config.ISCSI_CONNECTIVITY_TYPE], connectivity_type)
 
-        host_munch_ret_4 = Munch({'id': 'host_id_2', 'name': 'test_host_3',
+    def test_get_host_by_identifiers_return_iscsi_host_with_string_iqn(self):
+        host_munch_ret_1 = Munch({'id': 'host_id_1', 'name': 'test_host_1',
+                                  'WWPN': ['abc1']})
+        host_munch_ret_2 = Munch({'id': 'host_id_2', 'name': 'test_host_3',
                                   'iscsi_name': 'iqn.test.2',
                                   'WWPN': ['abc3']})
-        ret4 = Munch(as_single_element=host_munch_ret_4)
-        self.svc.client.svcinfo.lshost.side_effect = [ret1, ret4, ret3]
-        host, connectivity_type = self.svc.get_host_by_host_identifiers(
-            Initiators('iqn.test.2', ['abcd3']))
+        host_munch_ret_3 = Munch({'id': 'host_id_3', 'name': 'test_host_3',
+                                  'WWPN': ['abc3'],
+                                  'iscsi_name': 'iqn.test.3'})
+        ret1 = [host_munch_ret_1, host_munch_ret_2]
+        ret2 = Munch(as_single_element=host_munch_ret_2)
+        ret3 = Munch(as_single_element=host_munch_ret_3)
+        self.svc.client.svcinfo.lshost.side_effect = [ret1, ret2, ret3]
+        host, connectivity_type = self.svc.get_host_by_host_identifiers(Initiators(
+            'iqn.test.2', ['abcd3']))
+        self.assertEqual('test_host_3', host)
+        self.assertEqual([config.ISCSI_CONNECTIVITY_TYPE], connectivity_type)
+
+    def test_get_host_by_identifiers_return_iscsi_host_with_list_iqn(self):
+        host_munch_ret_1 = Munch({'id': 'host_id_1', 'name': 'test_host_1',
+                                  'WWPN': ['abc1']})
+        host_munch_ret_2 = Munch({'id': 'host_id_2', 'name': 'test_host_3',
+                                  'iscsi_name': ['iqn.test.2', 'iqn.test.22'],
+                                  'WWPN': ['abc3']})
+        host_munch_ret_3 = Munch({'id': 'host_id_3', 'name': 'test_host_3',
+                                  'WWPN': ['abc3'],
+                                  'iscsi_name': 'iqn.test.3'})
+        ret1 = [host_munch_ret_1, host_munch_ret_2]
+        ret2 = Munch(as_single_element=host_munch_ret_2)
+        ret3 = Munch(as_single_element=host_munch_ret_3)
+        self.svc.client.svcinfo.lshost.side_effect = [ret1, ret2, ret3]
+        host, connectivity_type = self.svc.get_host_by_host_identifiers(Initiators(
+            'iqn.test.2', ['abcd3']))
         self.assertEqual('test_host_3', host)
         self.assertEqual([config.ISCSI_CONNECTIVITY_TYPE], connectivity_type)
 
@@ -297,7 +323,7 @@ class TestArrayMediatorSVC(unittest.TestCase):
         host_munch_ret_1 = Munch({'id': 'host_id_1', 'name': 'test_host_1',
                                   'WWPN': ['abc1']})
         host_munch_ret_2 = Munch({'id': 'host_id_2', 'name': 'test_host_3',
-                                  'iscsi_name': 'iqn.test.2',
+                                  'iscsi_name': '',
                                   'WWPN': 'abc3'})
         host_munch_ret_3 = Munch({'id': 'host_id_3', 'name': 'test_host_3',
                                   'WWPN': ['abc1', 'abc3'],


### PR DESCRIPTION
Bug fix for CSI-528
The root cause is that our code will converts the iqn to a list regardless of whether it is a list or not

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ibm-block-csi-driver/86)
<!-- Reviewable:end -->
