### PR TITLE
Feature/csi 500 yaml safe load

### DIFF
--- a/controller/controller_server/csi_controller_server.py
+++ b/controller/controller_server/csi_controller_server.py
@@ -38,7 +38,7 @@ class ControllerServicer(csi_pb2_grpc.ControllerServicer):
         path = os.path.join(my_path, "../../common/config.yaml")
 
         with open(path, 'r') as yamlfile:
-            self.cfg = yaml.load(yamlfile)  # TODO: add the following when possible : Loader=yaml.FullLoader)
+            self.cfg = yaml.safe_load(yamlfile)  # TODO: add the following when possible : Loader=yaml.FullLoader)
 
     def CreateVolume(self, request, context):
         set_current_thread_name(request.name)


### PR DESCRIPTION
[CSI security code scan]: Use of unsafe yaml load
Use safe_load instead of load to load yaml file in controller

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ibm-block-csi-driver/90)
<!-- Reviewable:end -->
