### PR TITLE
Improve/ubi7 per Redhat support matrix + Updage version for GA 1.0.0

### DIFF
--- a/Dockerfile-csi-controller
+++ b/Dockerfile-csi-controller
@@ -18,8 +18,8 @@ MAINTAINER IBM Storage
 ###Required Labels
 LABEL name="IBM block storage CSI driver controller" \
       vendor="IBM" \
-      version="0.9.0" \
-      release="b62" \
+      version="1.0.0" \
+      release="b78" \
       summary="The controller component of the IBM block storage CSI driver" \
       description="The IBM block storage CSI driver enables container orchestrators, such as Kubernetes and OpenShift, to manage the life-cycle of persistent storage." \
       io.k8s.display-name="IBM block storage CSI driver controller" \

--- a/Dockerfile-csi-controller
+++ b/Dockerfile-csi-controller
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/python-36:1
+FROM registry.access.redhat.com/ubi8/python-36:1-58
 MAINTAINER IBM Storage
 
 ###Required Labels

--- a/Dockerfile-csi-controller
+++ b/Dockerfile-csi-controller
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/python-36:1-58
+FROM registry.access.redhat.com/ubi7/python-36:1-56.1568971386
 MAINTAINER IBM Storage
 
 ###Required Labels

--- a/Dockerfile-csi-node
+++ b/Dockerfile-csi-node
@@ -27,7 +27,7 @@ COPY . .
 RUN make ibm-block-csi-driver
 
 # Final stage
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0-213
 MAINTAINER IBM Storage
 
 LABEL name="IBM block storage CSI driver node" \

--- a/Dockerfile-csi-node
+++ b/Dockerfile-csi-node
@@ -32,8 +32,8 @@ MAINTAINER IBM Storage
 
 LABEL name="IBM block storage CSI driver node" \
       vendor="IBM" \
-      version="0.9.0" \
-      release="b62" \
+      version="1.0.0" \
+      release="b78" \
       summary="The node component of the IBM block storage CSI driver" \
       description="The IBM block storage CSI driver enables container orchestrators, such as Kubernetes and OpenShift, to manage the life-cycle of persistent storage." \
       io.k8s.display-name="IBM block storage CSI driver node" \

--- a/Dockerfile-csi-node
+++ b/Dockerfile-csi-node
@@ -27,7 +27,7 @@ COPY . .
 RUN make ibm-block-csi-driver
 
 # Final stage
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0-213
+FROM registry.access.redhat.com/ubi7/ubi-minimal:7.7-138
 MAINTAINER IBM Storage
 
 LABEL name="IBM block storage CSI driver node" \

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Supported IBM storage systems:
 Supported operating systems:
   - RHEL 7.x (x86 architecture)
 
-DISCLAIMER: The driver is provided as is, without warranty. Version 0.9.0 of the IBM block storage CSI driver is a beta software version. Do not use this driver for production purposes and do not contact IBM for support. Any issue will be handled on a best-effort basis. 
+DISCLAIMER: The driver is provided as is, without warranty. Version 1.0.0 of the IBM block storage CSI driver is a beta software version. Do not use this driver for production purposes and do not contact IBM for support. Any issue will be handled on a best-effort basis. 
 
 ## Table of content:
 * [Prerequisites for driver installation](#prerequisites-for-driver-installation)
@@ -124,7 +124,7 @@ This section describes how to install the CSI driver.
 ###### Download the driver yml file from github:
 $> curl https://raw.githubusercontent.com/IBM/ibm-block-csi-driver/master/deploy/kubernetes/v1.13/ibm-block-csi-driver.yaml > ibm-block-csi-driver.yaml 
 
-###### Optional: Only edit the `ibm-block-csi-driver.yaml` file if you need to change the driver IMAGE URL. By default, the URL is `ibmcom/ibm-block-csi-driver-controller:0.9.0` and `ibmcom/ibm-block-csi-driver-node:0.9.0`.
+###### Optional: Only edit the `ibm-block-csi-driver.yaml` file if you need to change the driver IMAGE URL. By default, the URL is `ibmcom/ibm-block-csi-driver-controller:1.0.0` and `ibmcom/ibm-block-csi-driver-node:0.9.0`.
 
 ###### Install the driver:
 $> kubectl apply -f ibm-block-csi-driver.yaml

--- a/common/config.yaml
+++ b/common/config.yaml
@@ -1,6 +1,6 @@
 identity:
    name: block.csi.ibm.com
-   version: 0.9.0
+   version: 1.0.0
    capabilities: 
       - CONTROLLER_SERVICE
 

--- a/controller/tests/controller_server/csi_controller_server_test.py
+++ b/controller/tests/controller_server/csi_controller_server_test.py
@@ -766,7 +766,7 @@ class TestIdentityServer(unittest.TestCase):
     @patch.object(ControllerServicer, "_ControllerServicer__get_identity_config")
     def test_identity_plugin_get_info_succeeds(self, identity_config):
         plugin_name = "plugin-name"
-        version = "0.9.0"
+        version = "1.0.0"
         identity_config.side_effect = [plugin_name, version]
         request = Mock()
         context = Mock()
@@ -779,7 +779,7 @@ class TestIdentityServer(unittest.TestCase):
         request = Mock()
         context = Mock()
 
-        identity_config.side_effect = ["name", Exception(), Exception(), "0.9.0"]
+        identity_config.side_effect = ["name", Exception(), Exception(), "1.0.0"]
 
         res = self.servicer.GetPluginInfo(request, context)
         context.set_code.assert_called_once_with(grpc.StatusCode.INTERNAL)
@@ -794,7 +794,7 @@ class TestIdentityServer(unittest.TestCase):
         request = Mock()
         context = Mock()
 
-        identity_config.side_effect = ["", "0.9.0", "name", ""]
+        identity_config.side_effect = ["", "1.0.0", "name", ""]
 
         res = self.servicer.GetPluginInfo(request, context)
         context.set_code.assert_called_once_with(grpc.StatusCode.INTERNAL)

--- a/deploy/kubernetes/v1.13/ibm-block-csi-driver.yaml
+++ b/deploy/kubernetes/v1.13/ibm-block-csi-driver.yaml
@@ -1,4 +1,8 @@
 # ==============================================================
+#
+# Note: This yaml is deprecated.
+#       From version 1.0.0 the deployment method is via Operator -> https://github.com/ibm/ibm-block-csi-operator.
+#
 # IBM Block CSI driver - Kubernetes manifest.
 # The manifest contains:
 #    CSI controller (StatefulSet)
@@ -250,7 +254,7 @@ spec:
       serviceAccount: ibm-block-csi-controller-sa
       containers:
         - name: ibm-block-csi-controller
-          image: ibmcom/ibm-block-csi-driver-controller:0.9.0
+          image: ibmcom/ibm-block-csi-driver-controller:1.0.0
           imagePullPolicy: "IfNotPresent"
           args :
             - --csi-endpoint=$(CSI_ENDPOINT)
@@ -381,7 +385,7 @@ spec:
         - name: ibm-block-csi-node
           securityContext:
             privileged: true
-          image: ibmcom/ibm-block-csi-driver-node:0.9.0
+          image: ibmcom/ibm-block-csi-driver-node:9.0.0
           imagePullPolicy: "IfNotPresent"
           args:
             - --csi-endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/v1.14/ibm-block-csi-driver.yaml
+++ b/deploy/kubernetes/v1.14/ibm-block-csi-driver.yaml
@@ -1,4 +1,8 @@
 # ==============================================================
+#
+# Note: This yaml is deprecated.
+#       From version 1.0.0 the deployment method is via Operator -> https://github.com/ibm/ibm-block-csi-operator.
+#
 # IBM Block CSI driver - Kubernetes manifest.
 # The manifest contains:
 #    CSI controller (StatefulSet)
@@ -245,7 +249,7 @@ spec:
       serviceAccount: ibm-block-csi-controller-sa
       containers:
         - name: ibm-block-csi-controller
-          image: ibmcom/ibm-block-csi-driver-controller:0.9.0
+          image: ibmcom/ibm-block-csi-driver-controller:1.0.0
           imagePullPolicy: "IfNotPresent"
           args :
             - --csi-endpoint=$(CSI_ENDPOINT)
@@ -377,7 +381,7 @@ spec:
         - name: ibm-block-csi-node
           securityContext:
             privileged: true
-          image: ibmcom/ibm-block-csi-driver-node:0.9.0
+          image: ibmcom/ibm-block-csi-driver-node:1.0.0
           imagePullPolicy: "IfNotPresent"
           args:
             - --csi-endpoint=$(CSI_ENDPOINT)

--- a/node/pkg/driver/version_test.go
+++ b/node/pkg/driver/version_test.go
@@ -46,7 +46,7 @@ func TestGetVersion(t *testing.T) {
 	version, err := GetVersion(dir)
 
 	expected := VersionInfo{
-		DriverVersion: "0.9.0",
+		DriverVersion: "1.0.0",
 		GitCommit:     "",
 		BuildDate:     "",
 		GoVersion:     runtime.Version(),
@@ -76,7 +76,7 @@ func TestGetVersionJSON(t *testing.T) {
 	}
 
 	expected := fmt.Sprintf(`{
-  "driverVersion": "0.9.0",
+  "driverVersion": "1.0.0",
   "gitCommit": "",
   "buildDate": "",
   "goVersion": "%s",


### PR DESCRIPTION
**(A) update to UBI7 base image**
Per Redhat support matrix([HERE](https://access.redhat.com/support/policy/rhel-container-compatibility)), since CSI GA v1 support RHEL7.x worker nodes, then the related UBI image of the CSI container must be ubi7 and not ubi8.

So this PR change the node and controller base image
1. node -> ubi7/ubi-minimal:7.7-138  (instead of ubi8/ubi-minimal:8.0-213)
https://access.redhat.com/containers/#/registry.access.redhat.com/ubi7/ubi-minimal

2. controller -> ubi7/python-36:1-56.1568971386 (instead of ubi8/python-36:1-58)
https://access.redhat.com/containers/?tab=overview#/registry.access.redhat.com/ubi7/python-36

thanks @27149chen for catching this support matrix page. (CSI-574)
Also added PR for the operator as well -> https://github.com/IBM/ibm-block-csi-operator/pull/7

**(B) Update version to 1.0.0**
GA v1.0.0 is coming soon, therefor this PR also update the version from 0.9.0 -> 1.0.0.
Also update the version inside the CI build jobs according, so the new images will have 1.0.0 tag.

**(C) Add deprecated notice**
Add deprecated notice in the driver yaml `deploy/kubernetes/v1.*/ibm-block-csi-driver.yaml`
stating that "From version 1.0.0 the deployment method is via Operator -> https://github.com/ibm/ibm-block-csi-operator."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ibm-block-csi-driver/91)
<!-- Reviewable:end -->
