### PR TITLE
fix performance issue csi-536 slow svc map operation

### DIFF
--- a/controller/array_action/array_mediator_action.py
+++ b/controller/array_action/array_mediator_action.py
@@ -33,7 +33,7 @@ def map_volume(user, password, array_addresses, array_type, vol_id, initiators):
                 if mapping == host_name:
                     logger.debug("idempotent case - volume is already mapped to host.")
                     return mappings[mapping], connectivity_type, array_initiators
-            raise controller_errors.VolumeMappedToMultipleHostsError(mappings, vol_id)
+            raise controller_errors.VolumeMappedToMultipleHostsError(mappings)
 
         logger.debug(
             "no mappings were found for volume. mapping vol : {0} to host : {1}".format(

--- a/controller/array_action/array_mediator_action.py
+++ b/controller/array_action/array_mediator_action.py
@@ -1,0 +1,69 @@
+from controller.array_action.array_connection_manager import ArrayConnectionManager
+from controller.common.csi_logger import get_stdout_logger
+from controller.array_action.errors import NoConnectionAvailableException
+from controller.controller_server import utils
+from controller.controller_server import messages
+import controller.array_action.errors as controller_errors
+from controller.array_action.config import FC_CONNECTIVITY_TYPE
+
+from retry import retry
+
+logger = get_stdout_logger()
+
+@retry(NoConnectionAvailableException, tries=11, delay=1)
+def map_volume(user, password, array_addresses, array_type, vol_id, initiators):
+    with ArrayConnectionManager(user, password, array_addresses, array_type) as array_mediator:
+        host_name, connectivity_types = array_mediator.get_host_by_host_identifiers(initiators)
+
+        logger.debug(
+            "hostname : {}, connectivity_types  : {}".format(host_name,
+                                                              connectivity_types))
+
+        connectivity_type = utils.choose_connectivity_type(connectivity_types)
+
+        if FC_CONNECTIVITY_TYPE == connectivity_type:
+            array_initiators = array_mediator.get_array_fc_wwns(host_name)
+        else:
+            array_initiators = array_mediator.get_array_iqns()
+        mappings = array_mediator.get_volume_mappings(vol_id)
+        if len(mappings) >= 1:
+            logger.debug(
+                "{0} mappings have been found for volume. the mappings are: {1}".format(len(mappings), mappings))
+            if len(mappings) == 1:
+                mapping = list(mappings)[0]
+                if mapping == host_name:
+                    logger.debug("idempotent case - volume is already mapped to host.")
+                    return mappings[mapping], connectivity_type, array_initiators
+            err = messages.more_then_one_mapping_message.format(mappings)
+            raise controller_errors.MappingError(vol_id, host_name, err)
+
+        logger.debug(
+            "no mappings were found for volume. mapping vol : {0} to host : {1}".format(
+                vol_id, host_name))
+
+        try:
+            lun = array_mediator.map_volume(vol_id, host_name)
+            logger.debug("lun : {}".format(lun))
+        except controller_errors.LunAlreadyInUseError as ex:
+            logger.warning(
+                "Lun was already in use. re-trying the operation. {0}".format(
+                    ex))
+            for i in range(array_mediator.max_lun_retries - 1):
+                try:
+                    lun = array_mediator.map_volume(vol_id, host_name)
+                    break
+                except controller_errors.LunAlreadyInUseError as inner_ex:
+                    logger.warning(
+                        "re-trying map volume. try #{0}. {1}".format(i,
+                                                                     inner_ex))
+            else:  # will get here only if the for statement is false.
+                raise ex
+
+        return lun, connectivity_type, array_initiators
+
+@retry(NoConnectionAvailableException, tries=11, delay=1)
+def unmap_volume(user, password, array_addresses, array_type, vol_id, initiators):
+    with ArrayConnectionManager(user, password, array_addresses, array_type) as array_mediator:
+        host_name, _ = array_mediator.get_host_by_host_identifiers(initiators)
+
+        array_mediator.unmap_volume(vol_id, host_name)

--- a/controller/array_action/array_mediator_action.py
+++ b/controller/array_action/array_mediator_action.py
@@ -2,7 +2,6 @@ from controller.array_action.array_connection_manager import ArrayConnectionMana
 from controller.common.csi_logger import get_stdout_logger
 from controller.array_action.errors import NoConnectionAvailableException
 from controller.controller_server import utils
-from controller.controller_server import messages
 import controller.array_action.errors as controller_errors
 from controller.array_action.config import FC_CONNECTIVITY_TYPE
 
@@ -34,8 +33,7 @@ def map_volume(user, password, array_addresses, array_type, vol_id, initiators):
                 if mapping == host_name:
                     logger.debug("idempotent case - volume is already mapped to host.")
                     return mappings[mapping], connectivity_type, array_initiators
-            err = messages.more_then_one_mapping_message.format(mappings)
-            raise controller_errors.MappingError(vol_id, host_name, err)
+            raise controller_errors.VolumeMappedToMultipleHostsError(mappings, vol_id)
 
         logger.debug(
             "no mappings were found for volume. mapping vol : {0} to host : {1}".format(

--- a/controller/array_action/errors.py
+++ b/controller/array_action/errors.py
@@ -119,3 +119,8 @@ class BadNodeIdError(BaseArrayActionException):
 
     def __init__(self, name):
         self.message = messages.BadNodeIdError_message.format(name)
+
+class VolumeMappedToMultipleHostsError(BaseArrayActionException):
+
+    def __init__(self, hosts, vol):
+        self.message = messages.VolumeMappedToMultipleHostsError_message.format(hosts, vol)

--- a/controller/array_action/errors.py
+++ b/controller/array_action/errors.py
@@ -122,5 +122,5 @@ class BadNodeIdError(BaseArrayActionException):
 
 class VolumeMappedToMultipleHostsError(BaseArrayActionException):
 
-    def __init__(self, hosts, vol):
-        self.message = messages.VolumeMappedToMultipleHostsError_message.format(hosts, vol)
+    def __init__(self, hosts):
+        self.message = messages.VolumeMappedToMultipleHostsError_message.format(hosts)

--- a/controller/array_action/messages.py
+++ b/controller/array_action/messages.py
@@ -34,4 +34,4 @@ UnMappingError_message = "Unmapping error has occurred for vol : {0} and host : 
 
 BadNodeIdError_message = "Bad node id format for node id : {0}"
 
-VolumeMappedToMultipleHostsError_message = "Multiple hosts {0} found for the volume {1} mapping"
+VolumeMappedToMultipleHostsError_message = "Volume is already mapped to different hosts {0}"

--- a/controller/array_action/messages.py
+++ b/controller/array_action/messages.py
@@ -33,3 +33,5 @@ VolumeAlreadyUnmapped_message = "Volume: {0} is already unmapped."
 UnMappingError_message = "Unmapping error has occurred for vol : {0} and host : {1}. error : {2}"
 
 BadNodeIdError_message = "Bad node id format for node id : {0}"
+
+VolumeMappedToMultipleHostsError_message = "Multiple hosts {0} found for the volume {1} mapping"

--- a/controller/controller_server/csi_controller_server.py
+++ b/controller/controller_server/csi_controller_server.py
@@ -269,14 +269,14 @@ class ControllerServicer(csi_pb2_grpc.ControllerServicer):
                 return csi_pb2.ControllerPublishVolumeResponse()
 
             except controller_errors.NoConnectionAvailableException as ex:
-                logger.debug("no avaliable connections for the request vol {}".format(vol_id))
+                logger.debug("no avaliable connections for vol {}".format(vol_id))
                 logger.exception(ex)
                 logger.debug("sleep 1s when encounter NoConnectionAvailableException for vol {}".format(vol_id))
                 time.sleep(1)
                 retry += 1
                 #csiTimeout for kubelet is 15 second, it should give a response before it
                 if retry == 11:
-                    logger.debug("After 11 times retry, no avaliable connection for the request vol {}".format(vol_id))
+                    logger.debug("no avaliable connection for vol {} after 11 times retry".format(vol_id))
                     context.set_code(grpc.StatusCode.INTERNAL)
                     context.set_details('an internal exception occurred : {}'.format(ex))
                     return csi_pb2.ControllerPublishVolumeResponse()
@@ -337,14 +337,14 @@ class ControllerServicer(csi_pb2_grpc.ControllerServicer):
                 return csi_pb2.ControllerUnpublishVolumeResponse()
 
             except controller_errors.NoConnectionAvailableException as ex:
-                logger.debug("no avaliable connections for the request vol {}".format(vol_id))
+                logger.debug("no avaliable connections for vol {}".format(vol_id))
                 logger.exception(ex)
                 logger.debug("sleep 1s when encounter NoConnectionAvailableException for vol {}".format(vol_id))
                 time.sleep(1)
                 retry += 1
                 #csiTimeout for kubelet is 15 second, it should give a response before it
                 if retry == 11:
-                    logger.debug("After 11 times retry, no avaliable connection for the request vol {}".format(vol_id))
+                    logger.debug("no avaliable connection for vol {} after 11 times retry".format(vol_id))
                     context.set_code(grpc.StatusCode.INTERNAL)
                     context.set_details('an internal exception occurred : {}'.format(ex))
                     return csi_pb2.ControllerPublishVolumeResponse()

--- a/controller/controller_server/csi_controller_server.py
+++ b/controller/controller_server/csi_controller_server.py
@@ -269,6 +269,10 @@ class ControllerServicer(csi_pb2_grpc.ControllerServicer):
             context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
             return csi_pb2.ControllerPublishVolumeResponse()
 
+        except controller_errors.NoConnectionAvailableException as ex:
+            logger.exception(ex)
+            raise ex
+
         except Exception as ex:
             logger.debug("an internal exception occurred")
             logger.exception(ex)
@@ -321,6 +325,10 @@ class ControllerServicer(csi_pb2_grpc.ControllerServicer):
             context.set_details(ex.message)
             context.set_code(grpc.StatusCode.NOT_FOUND)
             return csi_pb2.ControllerUnpublishVolumeResponse()
+
+        except controller_errors.NoConnectionAvailableException as ex:
+            logger.exception(ex)
+            raise ex
 
         except Exception as ex:
             logger.debug("an internal exception occurred")

--- a/controller/controller_server/csi_controller_server.py
+++ b/controller/controller_server/csi_controller_server.py
@@ -19,6 +19,8 @@ import controller.controller_server.messages as messages
 from controller.common.utils import set_current_thread_name
 from controller.common.node_info import NodeIdInfo
 
+from retry import retry
+
 logger = None #is set in ControllerServicer::__init__
 
 
@@ -177,185 +179,155 @@ class ControllerServicer(csi_pb2_grpc.ControllerServicer):
         logger.info("finished DeleteVolume")
         return res
 
+    @retry(controller_errors.NoConnectionAvailableException, tries=11, delay=1)
     def ControllerPublishVolume(self, request, context):
         set_current_thread_name(request.volume_id)
         logger.info("ControllerPublishVolume")
-        retry = 0
-        while retry <11:
+        try:
+            utils.validate_publish_volume_request(request)
+
+            array_type, vol_id = utils.get_volume_id_info(request.volume_id)
+
+            node_id_info = NodeIdInfo(request.node_id)
+            node_name = node_id_info.node_name
+            initiators = node_id_info.initiators
+
+            logger.debug("node name for this publish operation is : {0}".format(node_name))
+
+            user, password, array_addresses = utils.get_array_connection_info_from_secret(request.secrets)
+
+            with ArrayConnectionManager(user, password, array_addresses, array_type) as array_mediator:
+
+                host_name, connectivity_types = array_mediator.get_host_by_host_identifiers(initiators)
+
+                logger.debug("hostname : {}, connectiivity_types  : {}".format(host_name, connectivity_types))
+
+                connectivity_type = utils.choose_connectivity_type(connectivity_types)
+
+                if FC_CONNECTIVITY_TYPE == connectivity_type:
+                    array_initiators = array_mediator.get_array_fc_wwns(host_name)
+                else:
+                    array_initiators = array_mediator.get_array_iqns()
+                mappings = array_mediator.get_volume_mappings(vol_id)
+                if len(mappings) >= 1:
+                    logger.debug(
+                        "{0} mappings have been found for volume. the mappings are: {1}".format(
+                            len(mappings), mappings))
+                    if len(mappings) == 1:
+                        mapping = list(mappings)[0]
+                        if mapping == host_name:
+                            logger.debug("idempotent case - volume is already mapped to host.")
+                            return utils.generate_csi_publish_volume_response(mappings[mapping], connectivity_type,
+                                                                              self.cfg, array_initiators)
+
+                    logger.error(messages.more_then_one_mapping_message.format(mappings))
+                    context.set_details(messages.more_then_one_mapping_message.format(mappings))
+                    context.set_code(grpc.StatusCode.FAILED_PRECONDITION)
+                    return csi_pb2.ControllerPublishVolumeResponse()
+
+                logger.debug("no mappings were found for volume. mapping vol : {0} to host : {1}".format(
+                    vol_id, host_name))
+
+                try:
+                    lun = array_mediator.map_volume(vol_id, host_name)
+                    logger.debug("lun : {}".format(lun))
+                except controller_errors.LunAlreadyInUseError as ex:
+                    logger.warning("Lun was already in use. re-trying the operation. {0}".format(ex))
+                    for i in range(array_mediator.max_lun_retries - 1):
+                        try:
+                            lun = array_mediator.map_volume(vol_id, host_name)
+                            break
+                        except controller_errors.LunAlreadyInUseError as inner_ex:
+                            logger.warning("re-trying map volume. try #{0}. {1}".format(i, inner_ex))
+                    else:    # will get here only if the for statement is false.
+                        raise ex
+                except controller_errors.PermissionDeniedError as ex:
+                    context.set_code(grpc.StatusCode.PERMISSION_DENIED)
+                    context.set_details(ex)
+                    return csi_pb2.ControllerPublishVolumeResponse()
+
+                logger.info("finished ControllerPublishVolume")
+                res = utils.generate_csi_publish_volume_response(lun, connectivity_type, self.cfg, array_initiators)
+                logger.debug("after res")
+                return res
+
+        except (controller_errors.LunAlreadyInUseError, controller_errors.NoAvailableLunError) as ex:
+            logger.exception(ex)
+            context.set_details(ex.message)
+            context.set_code(grpc.StatusCode.RESOURCE_EXHAUSTED)
+            return csi_pb2.ControllerPublishVolumeResponse()
+
+        except (controller_errors.HostNotFoundError, controller_errors.VolumeNotFoundError, controller_errors.BadNodeIdError) as ex:
+            logger.exception(ex)
+            context.set_details(ex.message)
+            context.set_code(grpc.StatusCode.NOT_FOUND)
+            return csi_pb2.ControllerPublishVolumeResponse()
+
+        except ValidationException as ex:
+            logger.exception(ex)
+            context.set_details(ex.message)
+            context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
+            return csi_pb2.ControllerPublishVolumeResponse()
+
+        except Exception as ex:
+            logger.debug("an internal exception occurred")
+            logger.exception(ex)
+            context.set_code(grpc.StatusCode.INTERNAL)
+            context.set_details('an internal exception occurred : {}'.format(ex))
+            return csi_pb2.ControllerPublishVolumeResponse()
+
+    @retry(controller_errors.NoConnectionAvailableException, tries=11, delay=1)
+    def ControllerUnpublishVolume(self, request, context):
+        set_current_thread_name(request.volume_id)
+        logger.info("ControllerUnpublishVolume")
+        try:
             try:
-                utils.validate_publish_volume_request(request)
-
-                array_type, vol_id = utils.get_volume_id_info(request.volume_id)
-
-                node_id_info = NodeIdInfo(request.node_id)
-                node_name = node_id_info.node_name
-                initiators = node_id_info.initiators
-
-                logger.debug("node name for this publish operation is : {0}".format(node_name))
-
-                user, password, array_addresses = utils.get_array_connection_info_from_secret(request.secrets)
-
-                with ArrayConnectionManager(user, password, array_addresses, array_type) as array_mediator:
-
-                    host_name, connectivity_types = array_mediator.get_host_by_host_identifiers(initiators)
-
-                    logger.debug("hostname : {}, connectiivity_types  : {}".format(host_name, connectivity_types))
-
-                    connectivity_type = utils.choose_connectivity_type(connectivity_types)
-
-                    if FC_CONNECTIVITY_TYPE == connectivity_type:
-                        array_initiators = array_mediator.get_array_fc_wwns(host_name)
-                    else:
-                        array_initiators = array_mediator.get_array_iqns()
-                    mappings = array_mediator.get_volume_mappings(vol_id)
-                    if len(mappings) >= 1:
-                        logger.debug(
-                            "{0} mappings have been found for volume. the mappings are: {1}".format(
-                                len(mappings), mappings))
-                        if len(mappings) == 1:
-                            mapping = list(mappings)[0]
-                            if mapping == host_name:
-                                logger.debug("idempotent case - volume is already mapped to host.")
-                                return utils.generate_csi_publish_volume_response(mappings[mapping], connectivity_type,
-                                                                                  self.cfg, array_initiators)
-
-                        logger.error(messages.more_then_one_mapping_message.format(mappings))
-                        context.set_details(messages.more_then_one_mapping_message.format(mappings))
-                        context.set_code(grpc.StatusCode.FAILED_PRECONDITION)
-                        return csi_pb2.ControllerPublishVolumeResponse()
-
-                    logger.debug("no mappings were found for volume. mapping vol : {0} to host : {1}".format(
-                        vol_id, host_name))
-
-                    try:
-                        lun = array_mediator.map_volume(vol_id, host_name)
-                        logger.debug("lun : {}".format(lun))
-                    except controller_errors.LunAlreadyInUseError as ex:
-                        logger.warning("Lun was already in use. re-trying the operation. {0}".format(ex))
-                        for i in range(array_mediator.max_lun_retries - 1):
-                            try:
-                                lun = array_mediator.map_volume(vol_id, host_name)
-                                break
-                            except controller_errors.LunAlreadyInUseError as inner_ex:
-                                logger.warning("re-trying map volume. try #{0}. {1}".format(i, inner_ex))
-                        else:    # will get here only if the for statement is false.
-                            raise ex
-                    except controller_errors.PermissionDeniedError as ex:
-                        context.set_code(grpc.StatusCode.PERMISSION_DENIED)
-                        context.set_details(ex)
-                        return csi_pb2.ControllerPublishVolumeResponse()
-
-                    logger.info("finished ControllerPublishVolume")
-                    res = utils.generate_csi_publish_volume_response(lun, connectivity_type, self.cfg, array_initiators)
-                    logger.debug("after res")
-                    return res
-
-            except (controller_errors.LunAlreadyInUseError, controller_errors.NoAvailableLunError) as ex:
-                logger.exception(ex)
-                context.set_details(ex.message)
-                context.set_code(grpc.StatusCode.RESOURCE_EXHAUSTED)
-                return csi_pb2.ControllerPublishVolumeResponse()
-
-            except (controller_errors.HostNotFoundError, controller_errors.VolumeNotFoundError, controller_errors.BadNodeIdError) as ex:
-                logger.exception(ex)
-                context.set_details(ex.message)
-                context.set_code(grpc.StatusCode.NOT_FOUND)
-                return csi_pb2.ControllerPublishVolumeResponse()
-
+                utils.validate_unpublish_volume_request(request)
             except ValidationException as ex:
                 logger.exception(ex)
                 context.set_details(ex.message)
                 context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
-                return csi_pb2.ControllerPublishVolumeResponse()
+                return csi_pb2.ControllerUnpublishVolumeResponse()
 
-            except controller_errors.NoConnectionAvailableException as ex:
-                logger.debug("no avaliable connections for vol {}".format(vol_id))
-                logger.exception(ex)
-                logger.debug("sleep 1s when encounter NoConnectionAvailableException for vol {}".format(vol_id))
-                time.sleep(1)
-                retry += 1
-                #csiTimeout for kubelet is 15 second, it should give a response before it
-                if retry == 11:
-                    logger.debug("no avaliable connection for vol {} after 11 times retry".format(vol_id))
-                    context.set_code(grpc.StatusCode.INTERNAL)
-                    context.set_details('an internal exception occurred : {}'.format(ex))
-                    return csi_pb2.ControllerPublishVolumeResponse()
-                continue
+            array_type, vol_id = utils.get_volume_id_info(request.volume_id)
 
-            except Exception as ex:
-                logger.debug("an internal exception occurred")
-                logger.exception(ex)
-                context.set_code(grpc.StatusCode.INTERNAL)
-                context.set_details('an internal exception occurred : {}'.format(ex))
-                return csi_pb2.ControllerPublishVolumeResponse()
+            node_id_info = NodeIdInfo(request.node_id)
+            node_name = node_id_info.node_name
+            initiators = node_id_info.initiators
+            logger.debug("node name for this unpublish operation is : {0}".format(node_name))
 
-    def ControllerUnpublishVolume(self, request, context):
-        set_current_thread_name(request.volume_id)
-        logger.info("ControllerUnpublishVolume")
-        retry = 0
-        while retry < 11:
-            try:
+            user, password, array_addresses = utils.get_array_connection_info_from_secret(request.secrets)
+
+            with ArrayConnectionManager(user, password, array_addresses, array_type) as array_mediator:
+
+                host_name, _ = array_mediator.get_host_by_host_identifiers(initiators)
                 try:
-                    utils.validate_unpublish_volume_request(request)
-                except ValidationException as ex:
-                    logger.exception(ex)
-                    context.set_details(ex.message)
-                    context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
+                    array_mediator.unmap_volume(vol_id, host_name)
+
+                except controller_errors.VolumeAlreadyUnmappedError as ex:
+                    logger.debug("Idempotent case. volume is already unmapped.")
                     return csi_pb2.ControllerUnpublishVolumeResponse()
 
-                array_type, vol_id = utils.get_volume_id_info(request.volume_id)
-
-                node_id_info = NodeIdInfo(request.node_id)
-                node_name = node_id_info.node_name
-                initiators = node_id_info.initiators
-                logger.debug("node name for this unpublish operation is : {0}".format(node_name))
-
-                user, password, array_addresses = utils.get_array_connection_info_from_secret(request.secrets)
-
-                with ArrayConnectionManager(user, password, array_addresses, array_type) as array_mediator:
-
-                    host_name, _ = array_mediator.get_host_by_host_identifiers(initiators)
-                    try:
-                        array_mediator.unmap_volume(vol_id, host_name)
-
-                    except controller_errors.VolumeAlreadyUnmappedError as ex:
-                        logger.debug("Idempotent case. volume is already unmapped.")
-                        return csi_pb2.ControllerUnpublishVolumeResponse()
-
-                    except controller_errors.PermissionDeniedError as ex:
-                        context.set_code(grpc.StatusCode.PERMISSION_DENIED)
-                        context.set_details(ex)
-                        return csi_pb2.ControllerPublishVolumeResponse()
-
-                logger.info("finished ControllerUnpublishVolume")
-                return csi_pb2.ControllerUnpublishVolumeResponse()
-
-            except (controller_errors.HostNotFoundError, controller_errors.VolumeNotFoundError) as ex:
-                logger.exception(ex)
-                context.set_details(ex.message)
-                context.set_code(grpc.StatusCode.NOT_FOUND)
-                return csi_pb2.ControllerUnpublishVolumeResponse()
-
-            except controller_errors.NoConnectionAvailableException as ex:
-                logger.debug("no avaliable connections for vol {}".format(vol_id))
-                logger.exception(ex)
-                logger.debug("sleep 1s when encounter NoConnectionAvailableException for vol {}".format(vol_id))
-                time.sleep(1)
-                retry += 1
-                #csiTimeout for kubelet is 15 second, it should give a response before it
-                if retry == 11:
-                    logger.debug("no avaliable connection for vol {} after 11 times retry".format(vol_id))
-                    context.set_code(grpc.StatusCode.INTERNAL)
-                    context.set_details('an internal exception occurred : {}'.format(ex))
+                except controller_errors.PermissionDeniedError as ex:
+                    context.set_code(grpc.StatusCode.PERMISSION_DENIED)
+                    context.set_details(ex)
                     return csi_pb2.ControllerPublishVolumeResponse()
-                continue
 
-            except Exception as ex:
-                logger.debug("an internal exception occurred")
-                logger.exception(ex)
-                context.set_code(grpc.StatusCode.INTERNAL)
-                context.set_details('an internal exception occurred : {}'.format(ex))
-                return csi_pb2.ControllerUnpublishVolumeResponse()
+            logger.info("finished ControllerUnpublishVolume")
+            return csi_pb2.ControllerUnpublishVolumeResponse()
+
+        except (controller_errors.HostNotFoundError, controller_errors.VolumeNotFoundError) as ex:
+            logger.exception(ex)
+            context.set_details(ex.message)
+            context.set_code(grpc.StatusCode.NOT_FOUND)
+            return csi_pb2.ControllerUnpublishVolumeResponse()
+
+        except Exception as ex:
+            logger.debug("an internal exception occurred")
+            logger.exception(ex)
+            context.set_code(grpc.StatusCode.INTERNAL)
+            context.set_details('an internal exception occurred : {}'.format(ex))
+            return csi_pb2.ControllerUnpublishVolumeResponse()
 
     def ValidateVolumeCapabilities(self, request, context):
         logger.info("ValidateVolumeCapabilities")

--- a/controller/controller_server/csi_controller_server.py
+++ b/controller/controller_server/csi_controller_server.py
@@ -11,11 +11,9 @@ from controller.array_action.array_connection_manager import ArrayConnectionMana
 from controller.common.csi_logger import get_stdout_logger
 from controller.common.csi_logger import set_log_level
 import controller.controller_server.config as config
-from controller.array_action.config import FC_CONNECTIVITY_TYPE
 import controller.controller_server.utils as utils
 import controller.array_action.errors as controller_errors
 from controller.controller_server.errors import ValidationException
-import controller.controller_server.messages as messages
 from controller.common.utils import set_current_thread_name
 from controller.common.node_info import NodeIdInfo
 from controller.array_action.array_mediator_action import map_volume, unmap_volume
@@ -202,7 +200,7 @@ class ControllerServicer(csi_pb2_grpc.ControllerServicer):
                                                          array_initiators)
             return res
 
-        except controller_errors.MappingError as ex:
+        except controller_errors.VolumeMappedToMultipleHostsError as ex:
             logger.exception(ex)
             context.set_details(ex.message)
             context.set_code(grpc.StatusCode.FAILED_PRECONDITION)

--- a/controller/controller_server/csi_controller_server.py
+++ b/controller/controller_server/csi_controller_server.py
@@ -181,7 +181,7 @@ class ControllerServicer(csi_pb2_grpc.ControllerServicer):
         set_current_thread_name(request.volume_id)
         logger.info("ControllerPublishVolume")
         attempts = 0
-        while attempts <100:
+        while attempts <4:
             try:
                 utils.validate_publish_volume_request(request)
 
@@ -275,7 +275,7 @@ class ControllerServicer(csi_pb2_grpc.ControllerServicer):
                 logger.debug("sleep 3s when encounter NoConnectionAvailableException for vol {}".format(vol_id))
                 time.sleep(3)
                 attempts += 1
-                if attempts == 100:
+                if attempts == 4:
                     logger.debug("After 100 times retry, no avaliable connection for the request vol {}".format(vol_id))
                     context.set_code(grpc.StatusCode.INTERNAL)
                     context.set_details('an internal exception occurred : {}'.format(ex))

--- a/controller/controller_server/csi_controller_server.py
+++ b/controller/controller_server/csi_controller_server.py
@@ -18,6 +18,7 @@ from controller.controller_server.errors import ValidationException
 import controller.controller_server.messages as messages
 from controller.common.utils import set_current_thread_name
 from controller.common.node_info import NodeIdInfo
+from controller.array_action.array_mediator_action import map_volume, unmap_volume
 
 logger = None #is set in ControllerServicer::__init__
 
@@ -192,74 +193,25 @@ class ControllerServicer(csi_pb2_grpc.ControllerServicer):
             logger.debug("node name for this publish operation is : {0}".format(node_name))
 
             user, password, array_addresses = utils.get_array_connection_info_from_secret(request.secrets)
+            lun, connectivity_type, array_initiators = map_volume(user, password, array_addresses, array_type, vol_id, initiators)
 
-            retry = 0
-            while retry < 11:
-                try:
-                    with ArrayConnectionManager(user, password, array_addresses, array_type) as array_mediator:
+            logger.info("finished ControllerPublishVolume")
+            res = utils.generate_csi_publish_volume_response(lun,
+                                                         connectivity_type,
+                                                         self.cfg,
+                                                         array_initiators)
+            return res
 
-                        host_name, connectivity_types = array_mediator.get_host_by_host_identifiers(initiators)
+        except controller_errors.MappingError as ex:
+            logger.exception(ex)
+            context.set_details(ex.message)
+            context.set_code(grpc.StatusCode.FAILED_PRECONDITION)
+            return csi_pb2.ControllerPublishVolumeResponse()
 
-                        logger.debug("hostname : {}, connectiivity_types  : {}".format(host_name, connectivity_types))
-
-                        connectivity_type = utils.choose_connectivity_type(connectivity_types)
-
-                        if FC_CONNECTIVITY_TYPE == connectivity_type:
-                            array_initiators = array_mediator.get_array_fc_wwns(host_name)
-                        else:
-                            array_initiators = array_mediator.get_array_iqns()
-                        mappings = array_mediator.get_volume_mappings(vol_id)
-                        if len(mappings) >= 1:
-                            logger.debug(
-                                "{0} mappings have been found for volume. the mappings are: {1}".format(
-                                    len(mappings), mappings))
-                            if len(mappings) == 1:
-                                mapping = list(mappings)[0]
-                                if mapping == host_name:
-                                    logger.debug("idempotent case - volume is already mapped to host.")
-                                    return utils.generate_csi_publish_volume_response(mappings[mapping], connectivity_type,
-                                                                                      self.cfg, array_initiators)
-
-                            logger.error(messages.more_then_one_mapping_message.format(mappings))
-                            context.set_details(messages.more_then_one_mapping_message.format(mappings))
-                            context.set_code(grpc.StatusCode.FAILED_PRECONDITION)
-                            return csi_pb2.ControllerPublishVolumeResponse()
-
-                        logger.debug("no mappings were found for volume. mapping vol : {0} to host : {1}".format(
-                            vol_id, host_name))
-
-                        try:
-                            lun = array_mediator.map_volume(vol_id, host_name)
-                            logger.debug("lun : {}".format(lun))
-                        except controller_errors.LunAlreadyInUseError as ex:
-                            logger.warning("Lun was already in use. re-trying the operation. {0}".format(ex))
-                            for i in range(array_mediator.max_lun_retries - 1):
-                                try:
-                                    lun = array_mediator.map_volume(vol_id, host_name)
-                                    break
-                                except controller_errors.LunAlreadyInUseError as inner_ex:
-                                    logger.warning("re-trying map volume. try #{0}. {1}".format(i, inner_ex))
-                            else:    # will get here only if the for statement is false.
-                                raise ex
-                        except controller_errors.PermissionDeniedError as ex:
-                            context.set_code(grpc.StatusCode.PERMISSION_DENIED)
-                            context.set_details(ex)
-                            return csi_pb2.ControllerPublishVolumeResponse()
-
-                        logger.info("finished ControllerPublishVolume")
-                        res = utils.generate_csi_publish_volume_response(lun, connectivity_type, self.cfg, array_initiators)
-                        logger.debug("after res")
-                        return res
-
-                except controller_errors.NoConnectionAvailableException as ex:
-                    logger.debug("no avaliable connections for vol {}".format(vol_id))
-                    logger.debug("sleep 1s when encounter NoConnectionAvailableException for vol {}".format(vol_id))
-                    time.sleep(1)
-                    retry += 1
-                    # csiTimeout for kubelet is 15 second, it should give a response before it
-                    if retry == 11:
-                        raise ex
-                    continue
+        except controller_errors.PermissionDeniedError as ex:
+            context.set_code(grpc.StatusCode.PERMISSION_DENIED)
+            context.set_details(ex)
+            return csi_pb2.ControllerPublishVolumeResponse()
 
         except (controller_errors.LunAlreadyInUseError, controller_errors.NoAvailableLunError) as ex:
             logger.exception(ex)
@@ -307,35 +259,19 @@ class ControllerServicer(csi_pb2_grpc.ControllerServicer):
 
             user, password, array_addresses = utils.get_array_connection_info_from_secret(request.secrets)
 
-            retry = 0
-            while retry < 11:
-                try:
-                    with ArrayConnectionManager(user, password, array_addresses, array_type) as array_mediator:
+            unmap_volume(user, password, array_addresses, array_type, vol_id, initiators)
 
-                        host_name, _ = array_mediator.get_host_by_host_identifiers(initiators)
-                        try:
-                            array_mediator.unmap_volume(vol_id, host_name)
+            logger.info("finished ControllerUnpublishVolume")
+            return csi_pb2.ControllerUnpublishVolumeResponse()
 
-                        except controller_errors.VolumeAlreadyUnmappedError as ex:
-                            logger.debug("Idempotent case. volume is already unmapped.")
-                            return csi_pb2.ControllerUnpublishVolumeResponse()
+        except controller_errors.VolumeAlreadyUnmappedError as ex:
+            logger.debug("Idempotent case. volume is already unmapped.")
+            return csi_pb2.ControllerUnpublishVolumeResponse()
 
-                        except controller_errors.PermissionDeniedError as ex:
-                            context.set_code(grpc.StatusCode.PERMISSION_DENIED)
-                            context.set_details(ex)
-                            return csi_pb2.ControllerPublishVolumeResponse()
-
-                    logger.info("finished ControllerUnpublishVolume")
-                    return csi_pb2.ControllerUnpublishVolumeResponse()
-                except controller_errors.NoConnectionAvailableException as ex:
-                    logger.debug("no avaliable connections for vol {}".format(vol_id))
-                    logger.debug("sleep 1s when encounter NoConnectionAvailableException for vol {}".format(vol_id))
-                    time.sleep(1)
-                    retry += 1
-                    # csiTimeout for kubelet is 15 second, it should give a response before it
-                    if retry == 11:
-                        raise ex
-                    continue
+        except controller_errors.PermissionDeniedError as ex:
+            context.set_code(grpc.StatusCode.PERMISSION_DENIED)
+            context.set_details(ex)
+            return csi_pb2.ControllerPublishVolumeResponse()
 
         except (controller_errors.HostNotFoundError, controller_errors.VolumeNotFoundError) as ex:
             logger.exception(ex)

--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -8,3 +8,4 @@ munch==2.3.2
 pyxcli==1.2.1
 # SVC python client
 pysvc==1.1.1
+retry==0.9.2

--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -3,9 +3,9 @@ grpcio-tools==1.20.1
 protobuf==3.7.1
 pyyaml==5.1
 munch==2.3.2
+retry==0.9.2
 
 # A9000 python client
 pyxcli==1.2.1
 # SVC python client
 pysvc==1.1.1
-retry==0.9.2


### PR DESCRIPTION
fix the performance issue "CSI-536 slow svc map operation" for ControllerPublishVolume/ControllerUnpublishVolume

since we only have 2 storage ssh connections to handle grpc request, so it's easily to encounter the Exception NoConnectionAvailableException.
when external-attacher receives grpc error, it will put this VA(VolumeAttachment) back to vaQueue with exponential backoff retry time(that is delay to put it back to queue).
so the request interval will reach 5 minutes after several times failure(retryIntervalMax is 5*time.Minute)

solution
set a timeout 11s(since csiTimeout for kubelet is 15 second), during this time, retry to map volume if encounter the NoConnectionAvailableException, response to external-attacher after the timeout

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ibm-block-csi-driver/92)
<!-- Reviewable:end -->
