### PR TITLE
add defer to close multipath disk in FlushMultipathDevice

### DIFF
--- a/node/pkg/driver/device_connectivity/device_connectivity_helper_scsigeneric.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_helper_scsigeneric.go
@@ -206,16 +206,10 @@ func (r OsDeviceConnectivityHelperScsiGeneric) FlushMultipathDevice(mpathDevice 
 	r.MutexMultipathF.Unlock()
 
 	if err != nil {
-		if file, errOpen := os.Open(fullDevice); errOpen != nil {
-			if os.IsNotExist(errOpen) {
-				logger.Debugf("Mpath device {%v} was deleted", fullDevice)
-			} else {
-				logger.Errorf("Error while opening file : {%v}. error: {%v}. Means the multipath -f {%v} did not succeed to delete the device.", fullDevice, errOpen.Error(), fullDevice)
-				return errOpen
-			}
+		if _, err := os.Stat(fullDevice); os.IsNotExist(err) {
+			logger.Debugf("Mpath device {%v} was deleted", fullDevice)
 		} else {
 			logger.Errorf("multipath -f {%v} did not succeed to delete the device. err={%v}", fullDevice, err.Error())
-			defer file.Close()
 			return err
 		}
 	}

--- a/node/pkg/driver/device_connectivity/device_connectivity_helper_scsigeneric.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_helper_scsigeneric.go
@@ -206,7 +206,7 @@ func (r OsDeviceConnectivityHelperScsiGeneric) FlushMultipathDevice(mpathDevice 
 	r.MutexMultipathF.Unlock()
 
 	if err != nil {
-		if _, errOpen := os.Open(fullDevice); errOpen != nil {
+		if file, errOpen := os.Open(fullDevice); errOpen != nil {
 			if os.IsNotExist(errOpen) {
 				logger.Debugf("Mpath device {%v} was deleted", fullDevice)
 			} else {
@@ -215,6 +215,7 @@ func (r OsDeviceConnectivityHelperScsiGeneric) FlushMultipathDevice(mpathDevice 
 			}
 		} else {
 			logger.Errorf("multipath -f {%v} did not succeed to delete the device. err={%v}", fullDevice, err.Error())
+			defer file.Close()
 			return err
 		}
 	}


### PR DESCRIPTION
in the func FlushMultipathDevice, we use os.Open to open the multipath disk to check whether the disk exists or not, but we forget to close it after that.
this causes: 
if we run the "multipath -f /dev/dm-x" failed at the first time, we try to run this command again, we will get an error, it says "the disk map in use".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ibm-block-csi-driver/95)
<!-- Reviewable:end -->
