### PR TITLE
CSI-481_secret_stringData

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,10 +169,11 @@ metadata:
   name: <VALUE-1>
   namespace: kube-system
 type: Opaque
+stringData:
+  management_address: <VALUE-2,VALUE-3> # Array managment addresses
+  username: <VALUE-4>                   # Array username.  
 data:
-  username: <VALUE-2 base64>        # Array username.
-  password: <VALUE-3 base64>        # Array password.
-  management_address: <VALUE-4 base64,VALUE-5 base64> # Array managment addresses
+  password: <VALUE-5 base64>            # Array password.
 ```
 
 Apply the secret:

--- a/USAGE-DETAILS.md
+++ b/USAGE-DETAILS.md
@@ -21,10 +21,11 @@ metadata:
   name: a9000-array1
   namespace: kube-system
 type: Opaque
+stringData:
+  management_address: <VALUE-2>     # Replace with valid FlashSystem A9000 management address
+  username: <VALUE-3>               # Replace with valid username
 data:
-  username: <VALUE-2 base64>   # Replace with valid username
-  password: <VALUE-3 base64>   # Replace with valid password
-  management_address: <VALUE-4 base64>   # Replace with valid FlashSystem A9000 management address
+  password: <VALUE-4 base64>        # Replace with valid password
   
 $> kubectl create -f demo-secret-a9000-array1.yaml
 secret/a9000-array1 created

--- a/deploy/kubernetes/examples/template-array-secret.yaml
+++ b/deploy/kubernetes/examples/template-array-secret.yaml
@@ -9,7 +9,8 @@ metadata:
   name: <VALUE-1>
   namespace: kube-system
 type: Opaque
+stringData:
+  management_address: <VALUE-2,VALUE-3> # Array managment addresses
+  username: <VALUE-4>                   # Array username.
 data:
-  username: <VALUE-2 base64>        # Array username.
-  password: <VALUE-3 base64>        # Array password.
-  management_address: <VALUE-4 base64,VALUE-5 base64> # Array managment addresses
+  password: <VALUE-5 base64>            # Array password.


### PR DESCRIPTION
Use stringData for storage address and usernames
No code change is needed. Updated only readme.

so instead of 
```
kind: Secret
apiVersion: v1
metadata:
   name: <VALUE-1>
   namespace: kube-system
 type: Opaque
 data:
   username: <VALUE-2 base64>        # Array username.
   password: <VALUE-3 base64>        # Array password.
   management_address: <VALUE-4 base64,VALUE-5 base64> # Array managment addresses

```

user can do this:
```
kind: Secret
apiVersion: v1
metadata:
   name: <VALUE-1>
   namespace: kube-system
 type: Opaque
 stringData:
   management_address: <VALUE-2,VALUE-3> # Array managment addresses
   username: <VALUE-4>                   # Array username.  
 data:
   password: <VALUE-5 base64>            # Array password.

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ibm-block-csi-driver/96)
<!-- Reviewable:end -->
