### PR TITLE
improvment/csi-477 XFS as the default fstype instead of ext4

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ parameters:
   csi.storage.k8s.io/controller-publish-secret-name: <VALUE_ARRAY_SECRET>
   csi.storage.k8s.io/controller-publish-secret-namespace: <VALUE_ARRAY_SECRET_NAMESPACE>
 
-  csi.storage.k8s.io/fstype: xfs   # Optional: Values ext4/xfs. The default is ext4.
+  csi.storage.k8s.io/fstype: xfs   # Optional: Values ext4/xfs. The default is xfs.
 ```
 
 Apply the storage class:

--- a/USAGE-DETAILS.md
+++ b/USAGE-DETAILS.md
@@ -44,7 +44,7 @@ parameters:
   csi.storage.k8s.io/controller-publish-secret-name: a9000-array1
   csi.storage.k8s.io/controller-publish-secret-namespace: kube-system
 
-  csi.storage.k8s.io/fstype: xfs   # Optional. values ext4/xfs. The default is ext4.
+  csi.storage.k8s.io/fstype: xfs   # Optional. values ext4/xfs. The default is xfs.
   volume_name_prefix: demo1        # Optional.
 
 $> kubectl create -f demo-storageclass-gold-A9000R.yaml

--- a/deploy/kubernetes/examples/demo-storageclass-gold-A9000R.yaml
+++ b/deploy/kubernetes/examples/demo-storageclass-gold-A9000R.yaml
@@ -15,5 +15,5 @@ parameters:
   csi.storage.k8s.io/controller-publish-secret-name: a9000-array1
   csi.storage.k8s.io/controller-publish-secret-namespace: kube-system
 
-  csi.storage.k8s.io/fstype: xfs   # Optional. values ext4\xfs. The default is ext4.
+  csi.storage.k8s.io/fstype: xfs   # Optional. values ext4\xfs. The default is xfs.
   volume_name_prefix: demo1        # Optional.

--- a/deploy/kubernetes/examples/template-storageclass.yaml
+++ b/deploy/kubernetes/examples/template-storageclass.yaml
@@ -20,6 +20,6 @@ parameters:
   csi.storage.k8s.io/controller-publish-secret-namespace: <VALUE_ARRAY_SECRET_NAMESPACE>
 
 
-  #csi.storage.k8s.io/fstype: <VALUE_FSTYPE>   # Optional. values ext4\xfs. The default is ext4.
+  #csi.storage.k8s.io/fstype: <VALUE_FSTYPE>   # Optional. values ext4\xfs. The default is xfs.
   #volume_name_prefix: <VALUE_PREFIX>          # Optional.
 

--- a/node/pkg/driver/node.go
+++ b/node/pkg/driver/node.go
@@ -49,7 +49,7 @@ var (
 		},
 	}
 
-	defaultFSType              = "ext4"
+	defaultFSType              = "xfs"
 	stageInfoFilename          = ".stageInfo.json"
 	supportedConnectivityTypes = map[string]bool{
 		"iscsi": true,


### PR DESCRIPTION
Use default file system xfs instead of ext4
Changed default value in node.go and few relevant comments and text files (e..g. readme).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ibm-block-csi-driver/97)
<!-- Reviewable:end -->
