### PR TITLE
update FlushMultipathDevice to fix nil pointer dereference issue

### DIFF
--- a/node/pkg/driver/device_connectivity/device_connectivity_helper_scsigeneric.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_helper_scsigeneric.go
@@ -206,7 +206,7 @@ func (r OsDeviceConnectivityHelperScsiGeneric) FlushMultipathDevice(mpathDevice 
 	r.MutexMultipathF.Unlock()
 
 	if err != nil {
-		if _, err := os.Stat(fullDevice); os.IsNotExist(err) {
+		if _, e := os.Stat(fullDevice); os.IsNotExist(e) {
 			logger.Debugf("Mpath device {%v} was deleted", fullDevice)
 		} else {
 			logger.Errorf("multipath -f {%v} did not succeed to delete the device. err={%v}", fullDevice, err.Error())


### PR DESCRIPTION
fix the node crash issue
when "multipath -f dm-x" is timeout, the os.Stat(fullDevice) will return nil to the err, then call err.Error() will get a panic

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ibm-block-csi-driver/102)
<!-- Reviewable:end -->
