### PR TITLE
Update/CSI-1837 utils mounter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,5 @@ require (
 	google.golang.org/grpc v1.22.0
 	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/apimachinery v0.0.0-20190727130956-f97a4e5b4abc
-	k8s.io/klog v0.3.3 // indirect
-	k8s.io/kubernetes v1.13.10
-	k8s.io/utils v0.0.0-20190712204705-3dccf664f023 // indirect
+	k8s.io/utils v0.0.0-20200912215256-4140de9c8800
 )

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.12
 require (
 	github.com/container-storage-interface/spec v1.1.0
 	github.com/golang/mock v1.3.1
-	github.com/pkg/errors v0.8.1 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,6 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1 h1:G5FRp8JnTd7RQH5kemVNlMeyXQAztQ3mOWV95KxsXH8=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
-github.com/golang/mock v1.2.0 h1:28o5sBqPkBsMGnC6b4MvE2TzSr5/AT4c/1fLqVGIwlk=
-github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.1 h1:qGJ6qTW+x6xX/my+8YUVl4WNpX9B7+/l2tRsHGZ7f2s=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -64,8 +62,6 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -139,8 +135,6 @@ k8s.io/klog v0.3.1/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.3 h1:niceAagH1tzskmaie/icWd7ci1wbG7Bf2c6YGcQv+3c=
 k8s.io/klog v0.3.3/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/kube-openapi v0.0.0-20190709113604-33be087ad058/go.mod h1:nfDlWeOsu3pUf4yWGL+ERqohP4YsZcBJXWMK+gkzOA4=
-k8s.io/kubernetes v1.13.1 h1:IwCCcPOZwY9rKcQyBJYXAE4Wgma4oOW5NYR3HXKFfZ8=
-k8s.io/kubernetes v1.13.1/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/kubernetes v1.13.10 h1:sClbFNFQrZcelEnDtD+bGYMB1WU/lexJNDYpTJnMFaY=
 k8s.io/kubernetes v1.13.10/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/utils v0.0.0-20190712204705-3dccf664f023 h1:1H4Jyzb0z2X0GfBMTwRjnt5ejffRHrGftUgJcV/ZfDc=

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
+github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+35s3my2LFTysnkMfxsJBAMHj/DoqoB9knIWoYG/Vk0=
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=
 github.com/go-openapi/spec v0.0.0-20160808142527-6aced65f8501/go.mod h1:J8+jY1nAiCcj+friV/PDoE1/3eeccG9LYBs0tYvLOWc=
@@ -130,14 +132,11 @@ k8s.io/apimachinery v0.0.0-20190727130956-f97a4e5b4abc h1:fi1vG9UrnqoGU/H2HP2rr7
 k8s.io/apimachinery v0.0.0-20190727130956-f97a4e5b4abc/go.mod h1:eXR4ljjmbwK6Ng0PKsXRySPXnTUy/qBUa6kPDeckhQ0=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
-k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.1/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
-k8s.io/klog v0.3.3 h1:niceAagH1tzskmaie/icWd7ci1wbG7Bf2c6YGcQv+3c=
-k8s.io/klog v0.3.3/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
+k8s.io/klog/v2 v2.0.0 h1:Foj74zO6RbjjP4hBEKjnYtjjAhGg4jNynUdYF6fJrok=
+k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/kube-openapi v0.0.0-20190709113604-33be087ad058/go.mod h1:nfDlWeOsu3pUf4yWGL+ERqohP4YsZcBJXWMK+gkzOA4=
-k8s.io/kubernetes v1.13.10 h1:sClbFNFQrZcelEnDtD+bGYMB1WU/lexJNDYpTJnMFaY=
-k8s.io/kubernetes v1.13.10/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
-k8s.io/utils v0.0.0-20190712204705-3dccf664f023 h1:1H4Jyzb0z2X0GfBMTwRjnt5ejffRHrGftUgJcV/ZfDc=
-k8s.io/utils v0.0.0-20190712204705-3dccf664f023/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
+k8s.io/utils v0.0.0-20200912215256-4140de9c8800 h1:9ZNvfPvVIEsp/T1ez4GQuzCcCTEQWhovSofhqR73A6g=
+k8s.io/utils v0.0.0-20200912215256-4140de9c8800/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/node/pkg/driver/driver.go
+++ b/node/pkg/driver/driver.go
@@ -30,7 +30,8 @@ import (
 	mountwrapper "github.com/ibm/ibm-block-csi-driver/node/pkg/driver/mount"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v2"
-	"k8s.io/kubernetes/pkg/util/mount"
+	"k8s.io/utils/exec"
+	"k8s.io/utils/mount"
 )
 
 type Driver struct {
@@ -49,7 +50,7 @@ func NewDriver(endpoint string, configFilePath string, hostname string) (*Driver
 
 	mounter := &mount.SafeFormatAndMount{
 		Interface: mountwrapper.New(""),
-		Exec:      mount.NewOsExec(),
+		Exec:      exec.New(),
 	}
 
 	syncLock := NewSyncLock()

--- a/node/pkg/driver/mount/mount_wrapper.go
+++ b/node/pkg/driver/mount/mount_wrapper.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/ibm/ibm-block-csi-driver/node/logger"
 	"github.com/ibm/ibm-block-csi-driver/node/pkg/driver/executer"
-	"k8s.io/kubernetes/pkg/util/mount"
+	"k8s.io/utils/mount"
 )
 
 // default mount/unmount timeout interval, 30s

--- a/node/pkg/driver/node.go
+++ b/node/pkg/driver/node.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ibm/ibm-block-csi-driver/node/pkg/driver/executer"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/kubernetes/pkg/util/mount"
+	"k8s.io/utils/mount"
 	"os"
 	"path"
 	"path/filepath"
@@ -409,7 +409,7 @@ func (d *NodeService) mountFileSystemVolume(mpathDevice string, targetPath strin
 	targetPathWithHostPrefix := d.NodeUtils.GetPodPath(targetPath)
 	if !isTargetPathExists {
 		logger.Debugf("Target path directory does not exist. Creating : {%v}", targetPathWithHostPrefix)
-		err := d.Mounter.MakeDir(targetPathWithHostPrefix)
+		err := d.NodeUtils.MakeDir(targetPathWithHostPrefix)
 		if err != nil {
 			return status.Errorf(codes.Internal, "Could not create directory %q: %v", targetPathWithHostPrefix, err)
 		}
@@ -425,14 +425,14 @@ func (d *NodeService) mountRawBlockVolume(mpathDevice string, targetPath string,
 	targetPathParentDirWithHostPrefix := filepath.Dir(targetPathWithHostPrefix)
 	if !d.NodeUtils.IsPathExists(targetPathParentDirWithHostPrefix) {
 		logger.Debugf("Target path parent directory does not exist. creating : {%v}", targetPathParentDirWithHostPrefix)
-		err := d.Mounter.MakeDir(targetPathParentDirWithHostPrefix)
+		err := d.NodeUtils.MakeDir(targetPathParentDirWithHostPrefix)
 		if err != nil {
 			return status.Errorf(codes.Internal, "Could not create directory %q: %v", targetPathParentDirWithHostPrefix, err)
 		}
 	}
 	if !isTargetPathExists {
 		logger.Debugf("Target path file does not exist. creating : {%v}", targetPathWithHostPrefix)
-		err := d.Mounter.MakeFile(targetPathWithHostPrefix)
+		err := d.NodeUtils.MakeFile(targetPathWithHostPrefix)
 		if err != nil {
 			return status.Errorf(codes.Internal, "Could not create file %q: %v", targetPathWithHostPrefix, err)
 		}

--- a/node/pkg/driver/node_test.go
+++ b/node/pkg/driver/node_test.go
@@ -635,7 +635,7 @@ func TestNodePublishVolume(t *testing.T) {
 				mockNodeUtils.EXPECT().ReadFromStagingInfoFile(stagingTargetFile).Return(stagingInfo, nil)
 				mockNodeUtils.EXPECT().GetPodPath(targetPath).Return(targetPathWithHostPrefix).AnyTimes()
 				mockNodeUtils.EXPECT().IsPathExists(targetPathWithHostPrefix).Return(false)
-				mockMounter.EXPECT().MakeDir(targetPathWithHostPrefix).Return(nil)
+				mockNodeUtils.EXPECT().MakeDir(targetPathWithHostPrefix).Return(nil)
 				mockMounter.EXPECT().FormatAndMount(mpathDevice, targetPath, fsTypeXfs, nil)
 
 				req := &csi.NodePublishVolumeRequest{
@@ -696,8 +696,8 @@ func TestNodePublishVolume(t *testing.T) {
 					mockNodeUtils.EXPECT().IsPathExists(targetPathWithHostPrefix).Return(false),
 					mockNodeUtils.EXPECT().IsPathExists(targetPathParentDirWithHostPrefix).Return(false),
 				)
-				mockMounter.EXPECT().MakeDir(targetPathParentDirWithHostPrefix).Return(nil)
-				mockMounter.EXPECT().MakeFile(gomock.Eq(targetPathWithHostPrefix)).Return(nil)
+				mockNodeUtils.EXPECT().MakeDir(targetPathParentDirWithHostPrefix).Return(nil)
+				mockNodeUtils.EXPECT().MakeFile(gomock.Eq(targetPathWithHostPrefix)).Return(nil)
 				mockMounter.EXPECT().Mount(mpathDevice, targetPath, "", []string{"bind"})
 
 				req := &csi.NodePublishVolumeRequest{

--- a/node/pkg/driver/node_test.go
+++ b/node/pkg/driver/node_test.go
@@ -636,6 +636,8 @@ func TestNodePublishVolume(t *testing.T) {
 				mockNodeUtils.EXPECT().GetPodPath(targetPath).Return(targetPathWithHostPrefix).AnyTimes()
 				mockNodeUtils.EXPECT().IsPathExists(targetPathWithHostPrefix).Return(false)
 				mockNodeUtils.EXPECT().MakeDir(targetPathWithHostPrefix).Return(nil)
+				mockMounter.EXPECT().GetDiskFormat(mpathDevice).Return("", nil)
+				mockNodeUtils.EXPECT().FormatDevice(mpathDevice, fsVolCap.GetMount().FsType)
 				mockMounter.EXPECT().FormatAndMount(mpathDevice, targetPath, fsTypeXfs, nil)
 
 				req := &csi.NodePublishVolumeRequest{

--- a/node/pkg/driver/node_utils.go
+++ b/node/pkg/driver/node_utils.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/ibm/ibm-block-csi-driver/node/logger"
 	"github.com/ibm/ibm-block-csi-driver/node/pkg/driver/executer"
-	"k8s.io/kubernetes/pkg/util/mount"
+	"k8s.io/utils/mount"
 )
 
 const (
@@ -57,6 +57,8 @@ type NodeUtilsInterface interface {
 	IsPathExists(filePath string) bool
 	IsDirectory(filePath string) bool
 	RemoveFileOrDirectory(filePath string) error
+	MakeDir(dirPath string) error
+	MakeFile(filePath string) error
 	IsNotMountPoint(file string) (bool, error)
 	GetPodPath(filepath string) string
 }
@@ -293,6 +295,27 @@ func (n NodeUtils) IsDirectory(path string) bool {
 // Deletes file or directory with all sub-directories and files
 func (n NodeUtils) RemoveFileOrDirectory(path string) error {
 	return os.RemoveAll(path)
+}
+
+func (n NodeUtils) MakeDir(dirPath string) error {
+	err := os.MkdirAll(dirPath, os.FileMode(0755))
+	if err != nil {
+		if !os.IsExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (n NodeUtils) MakeFile(filePath string) error {
+	f, err := os.OpenFile(filePath, os.O_CREATE, os.FileMode(0644))
+	defer f.Close()
+	if err != nil {
+		if !os.IsExist(err) {
+			return err
+		}
+	}
+	return nil
 }
 
 func (n NodeUtils) IsNotMountPoint(file string) (bool, error) {

--- a/node/pkg/driver/node_utils.go
+++ b/node/pkg/driver/node_utils.go
@@ -326,7 +326,10 @@ func (n NodeUtils) FormatDevice(devicePath string, fsType string) {
 	if fsType == "ext4" {
 		args = []string{"-m0", "-Enodiscard,lazy_itable_init=1,lazy_journal_init=1", devicePath}
 	} else if fsType == "xfs" {
-		args = []string{"-Enodiscard", devicePath}
+		args = []string{"-K", devicePath}
+	} else {
+		logger.Errorf("Could not format unsupported fsType: %v", fsType)
+		return
 	}
 
 	logger.Debugf("Formatting the device with fs_type = {%v}", fsType)

--- a/node/pkg/driver/node_utils.go
+++ b/node/pkg/driver/node_utils.go
@@ -27,7 +27,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/ibm/ibm-block-csi-driver/node/logger"
 	"github.com/ibm/ibm-block-csi-driver/node/pkg/driver/executer"
@@ -39,7 +38,7 @@ const (
 	// Command lines inside the container will show /host prefix.
 	PrefixChrootOfHostRoot  = "/host"
 	PublishContextSeparator = ","
-	mkfsTimeout             = 15 * time.Minute
+	mkfsTimeoutMilliseconds = 15 * 60 * 1000
 )
 
 //go:generate mockgen -destination=../../mocks/mock_node_utils.go -package=mocks github.com/ibm/ibm-block-csi-driver/node/pkg/driver NodeUtilsInterface
@@ -333,7 +332,7 @@ func (n NodeUtils) FormatDevice(devicePath string, fsType string) {
 	}
 
 	logger.Debugf("Formatting the device with fs_type = {%v}", fsType)
-	_, err := n.Executer.ExecuteWithTimeout(int(mkfsTimeout.Seconds()*1000), "mkfs."+fsType, args)
+	_, err := n.Executer.ExecuteWithTimeout(mkfsTimeoutMilliseconds, "mkfs."+fsType, args)
 	if err != nil {
 		logger.Errorf("Failed to run mkfs, error: %v", err)
 	}


### PR DESCRIPTION
Right after our [1.0.0 GA](https://github.com/IBM/ibm-block-csi-driver/pull/105), the mounter lib was [copied](https://github.com/kubernetes/utils/pull/100) from k8s to a separate repo, and [removed](https://github.com/kubernetes/kubernetes/pull/85305) from k8s.
This PR follows through.

In addition, "lazy format" optimization is introduced.