### PR TITLE
CSI-2153 make community test node log full

### DIFF
--- a/scripts/ci/run_community_csi_test.sh
+++ b/scripts/ci/run_community_csi_test.sh
@@ -9,6 +9,9 @@ mkdir -p build/reports && chmod 777 build/reports
 set +e
 ./scripts/ci/run_csi_test_client.sh csi-sanity-test `pwd`/build/reports/
 
-docker logs csi-controller > "csi_controller_run.log"
-docker logs csi-node > "csi_node_run.log"
+docker logs csi-controller >& "csi_controller_run.log"
+docker logs csi-node >& "csi_node_run.log"
 docker kill csi-controller
+docker kill csi-node
+docker rm csi-controller
+docker rm csi-node

--- a/scripts/ci/run_controller_server_for_csi_test.sh
+++ b/scripts/ci/run_controller_server_for_csi_test.sh
@@ -10,5 +10,5 @@ chmod 777 /tmp/k8s_dir
 [ $# -ne 1 ] && { echo "Usage $0 : container_name"  ; exit 1; }
 
 docker build -f Dockerfile-csi-controller -t csi-controller . &&  \
-docker run -v /tmp/k8s_dir:/tmp/k8s_dir:rw -d --network host --rm --name $1  csi-controller -e unix://tmp/k8s_dir/f
+docker run -v /tmp/k8s_dir:/tmp/k8s_dir:rw -d --network host --name $1  csi-controller -e unix://tmp/k8s_dir/f
 

--- a/scripts/ci/run_node_server_for_csi_test.sh
+++ b/scripts/ci/run_node_server_for_csi_test.sh
@@ -11,5 +11,5 @@ chmod 777 /tmp/k8s_dir
 
 docker build -f Dockerfile-csi-node -t csi-node . &&  \
 docker run --privileged -v /:/host:rshared -v /tmp/k8s_dir:/tmp/k8s_dir:rw \
--d --network host --ipc="host" --rm --name $1 \
+-d --network host --ipc="host" --name $1 \
 csi-node --csi-endpoint unix://tmp/k8s_dir/nodecsi --hostname=`hostname` --config-file-path=./config.yaml


### PR DESCRIPTION
remove the driver containers only after the logs were collected from both standard streams