### PR TITLE
CSI-1793 fix mounting a copy of xfs with same uuid

### DIFF
--- a/node/pkg/driver/node.go
+++ b/node/pkg/driver/node.go
@@ -432,8 +432,14 @@ func (d *NodeService) mountFileSystemVolume(mpathDevice string, targetPath strin
 		d.NodeUtils.FormatDevice(mpathDevice, fsType)
 	}
 
+	var mountOptions []string
+
+	if fsType == "xfs" {
+		mountOptions = append(mountOptions, "nouuid")
+	}
+
 	logger.Debugf("Mount the device with fs_type = {%v} (Create filesystem if needed)", fsType)
-	return d.Mounter.FormatAndMount(mpathDevice, targetPath, fsType, nil) // Passing without /host because k8s mounter uses mount\mkfs\fsck
+	return d.Mounter.FormatAndMount(mpathDevice, targetPath, fsType, mountOptions) // Passing without /host because k8s mounter uses mount\mkfs\fsck
 }
 
 func (d *NodeService) mountRawBlockVolume(mpathDevice string, targetPath string, isTargetPathExists bool) error {

--- a/node/pkg/driver/node_test.go
+++ b/node/pkg/driver/node_test.go
@@ -626,6 +626,7 @@ func TestNodePublishVolume(t *testing.T) {
 		{
 			name: "success with filesystem volume",
 			testFunc: func(t *testing.T) {
+				var mountOptions []string
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
 				mockMounter := mocks.NewMockNodeMounter(mockCtl)
@@ -638,7 +639,7 @@ func TestNodePublishVolume(t *testing.T) {
 				mockNodeUtils.EXPECT().MakeDir(targetPathWithHostPrefix).Return(nil)
 				mockMounter.EXPECT().GetDiskFormat(mpathDevice).Return("", nil)
 				mockNodeUtils.EXPECT().FormatDevice(mpathDevice, fsVolCap.GetMount().FsType)
-				mockMounter.EXPECT().FormatAndMount(mpathDevice, targetPath, fsTypeXfs, nil)
+				mockMounter.EXPECT().FormatAndMount(mpathDevice, targetPath, fsTypeXfs, mountOptions)
 
 				req := &csi.NodePublishVolumeRequest{
 					PublishContext:    map[string]string{},


### PR DESCRIPTION
allow mounting xfs uuid that is not unique, for scenarios with pvc from snapshot/clone.
similar to https://github.com/ceph/ceph-csi/pull/1009