### PR TITLE
Upgrade to ubi8

### DIFF
--- a/Dockerfile-csi-controller
+++ b/Dockerfile-csi-controller
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi7/python-38:1-21
+FROM registry.access.redhat.com/ubi8/python-38:1-41
 MAINTAINER IBM Storage
 
 ARG VERSION=1.4.0
@@ -30,7 +30,7 @@ LABEL name="IBM block storage CSI driver controller" \
       io.openshift.tags=ibm,csi,ibm-block-csi-driver,ibm-block-csi-node
 
 COPY controller/requirements.txt /driver/controller/
-RUN pip3 install --default-timeout=100 --upgrade pip==20.3.1
+RUN pip3 install --default-timeout=100 --upgrade pip==19.3.1
 # avoid default boringssl lib, since it does not support z systems
 ENV GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=True
 # TODO: remove CRYPTOGRAPHY_ALLOW_OPENSSL_102 when upgrading to ubi8

--- a/Dockerfile-csi-controller
+++ b/Dockerfile-csi-controller
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi7/python-38:1-20
+FROM registry.access.redhat.com/ubi7/python-38:1-21
 MAINTAINER IBM Storage
 
 ARG VERSION=1.4.0

--- a/Dockerfile-csi-controller
+++ b/Dockerfile-csi-controller
@@ -30,7 +30,7 @@ LABEL name="IBM block storage CSI driver controller" \
       io.openshift.tags=ibm,csi,ibm-block-csi-driver,ibm-block-csi-node
 
 COPY controller/requirements.txt /driver/controller/
-RUN pip3 install --default-timeout=100 --upgrade pip==19.3.1
+RUN pip3 install --default-timeout=100 --upgrade pip==20.3.1
 # avoid default boringssl lib, since it does not support z systems
 ENV GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=True
 # TODO: remove CRYPTOGRAPHY_ALLOW_OPENSSL_102 when upgrading to ubi8

--- a/Dockerfile-csi-controller.test
+++ b/Dockerfile-csi-controller.test
@@ -16,14 +16,12 @@
 #    This Dockerfile.test is for running the csi controller local tests inside a container.
 #    Its similar to the Dockerfile, but with additional requirements-tests.txt and ENTRYPOINT to run the local tests.
 
-FROM registry.access.redhat.com/ubi7/python-38:1-21
+FROM registry.access.redhat.com/ubi8/python-38:1-41
 
 COPY controller/requirements.txt /driver/controller/
-RUN pip3 install --upgrade pip==20.3.1
+RUN pip3 install --upgrade pip==19.3.1
 # avoid default boringssl lib, since it does not support z systems
 ENV GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=True
-# TODO: remove CRYPTOGRAPHY_ALLOW_OPENSSL_102 when upgrading to ubi8
-ENV CRYPTOGRAPHY_ALLOW_OPENSSL_102=true
 RUN pip3 install -r /driver/controller/requirements.txt
 
 # Requires to run local testing

--- a/Dockerfile-csi-controller.test
+++ b/Dockerfile-csi-controller.test
@@ -19,7 +19,7 @@
 FROM registry.access.redhat.com/ubi7/python-38:1-20
 
 COPY controller/requirements.txt /driver/controller/
-RUN pip3 install --upgrade pip==19.3.1
+RUN pip3 install --upgrade pip==20.3.1
 # avoid default boringssl lib, since it does not support z systems
 ENV GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=True
 # TODO: remove CRYPTOGRAPHY_ALLOW_OPENSSL_102 when upgrading to ubi8

--- a/Dockerfile-csi-controller.test
+++ b/Dockerfile-csi-controller.test
@@ -16,7 +16,7 @@
 #    This Dockerfile.test is for running the csi controller local tests inside a container.
 #    Its similar to the Dockerfile, but with additional requirements-tests.txt and ENTRYPOINT to run the local tests.
 
-FROM registry.access.redhat.com/ubi7/python-38:1-20
+FROM registry.access.redhat.com/ubi7/python-38:1-21
 
 COPY controller/requirements.txt /driver/controller/
 RUN pip3 install --upgrade pip==20.3.1

--- a/Dockerfile-csi-node
+++ b/Dockerfile-csi-node
@@ -27,7 +27,7 @@ COPY . .
 RUN make ibm-block-csi-driver
 
 # Final stage
-FROM registry.access.redhat.com/ubi7/ubi-minimal:7.9-224
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3-201
 MAINTAINER IBM Storage
 
 ARG VERSION=1.4.0


### PR DESCRIPTION
even CRYPTOGRAPHY_ALLOW_OPENSSL_102 won't make cryptography compile (the current `cryptography-3.3.1-cp36-abi3-manylinux2010` wheel supports only x86).
so we're actually downgrading our [Red Hat support](https://access.redhat.com/support/policy/rhel-container-compatibility) from Tier 2 to Tier 3 for users with RHEL 7.x worker machines.