### PR TITLE
CSI-2842 bump driver version to 1.6.0

### DIFF
--- a/Dockerfile-csi-controller
+++ b/Dockerfile-csi-controller
@@ -15,7 +15,7 @@
 FROM registry.access.redhat.com/ubi8/python-38:1-43.16099467811
 MAINTAINER IBM Storage
 
-ARG VERSION=1.5.0
+ARG VERSION=1.6.0
 ARG BUILD_NUMBER=0
 
 ###Required Labels

--- a/Dockerfile-csi-node
+++ b/Dockerfile-csi-node
@@ -30,7 +30,7 @@ RUN make ibm-block-csi-driver
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3-230
 MAINTAINER IBM Storage
 
-ARG VERSION=1.5.0
+ARG VERSION=1.6.0
 ARG BUILD_NUMBER=0
 
 LABEL name="IBM block storage CSI driver node" \

--- a/common/config.yaml
+++ b/common/config.yaml
@@ -1,6 +1,6 @@
 identity:
    name: block.csi.ibm.com
-   version: 1.5.0
+   version: 1.6.0
    capabilities: 
       Service: CONTROLLER_SERVICE
       VolumeExpansion: ONLINE

--- a/node/pkg/driver/version_test.go
+++ b/node/pkg/driver/version_test.go
@@ -46,7 +46,7 @@ func TestGetVersion(t *testing.T) {
 	version, err := GetVersion(dir)
 
 	expected := VersionInfo{
-		DriverVersion: "1.5.0",
+		DriverVersion: "1.6.0",
 		GitCommit:     "",
 		BuildDate:     "",
 		GoVersion:     runtime.Version(),
@@ -76,7 +76,7 @@ func TestGetVersionJSON(t *testing.T) {
 	}
 
 	expected := fmt.Sprintf(`{
-  "driverVersion": "1.5.0",
+  "driverVersion": "1.6.0",
   "gitCommit": "",
   "buildDate": "",
   "goVersion": "%s",


### PR DESCRIPTION
It's based on [this ](https://github.com/IBM/ibm-block-csi-driver/commit/eb4fe0d6afb46a26d74835c458302c839e9e6312)commit.