### PR TITLE
Task/csi 2691 printing the version in the logs

### DIFF
--- a/controller/controller_server/csi_controller_server.py
+++ b/controller/controller_server/csi_controller_server.py
@@ -659,7 +659,7 @@ class ControllerServicer(csi_pb2_grpc.ControllerServicer):
         except Exception as ex:
             logger.exception(ex)
             context.set_code(grpc.StatusCode.INTERNAL)
-            context.set_details('an error occured while trying to get plugin name or version')
+            context.set_details('an error occurred while trying to get plugin name or version')
             return csi_pb2.GetPluginInfoResponse()
 
         if not name or not version:
@@ -750,6 +750,8 @@ class ControllerServicer(csi_pb2_grpc.ControllerServicer):
         # controller_server.add_insecure_port('unix://{}'.format(self.server_port))
         controller_server.add_insecure_port(self.endpoint)
 
+        logger.info(f'Controller version: {self.__get_identity_config("version")}')
+
         # start the server
         logger.debug("Listening for connections on endpoint address: {}".format(self.endpoint))
 
@@ -793,8 +795,8 @@ def main():
 
     # start the server
     endpoint = arguments.endpoint
-    curr_server = ControllerServicer(endpoint)
-    curr_server.start_server()
+    controller_servicer = ControllerServicer(endpoint)
+    controller_servicer.start_server()
 
 
 if __name__ == '__main__':

--- a/controller/controller_server/csi_controller_server.py
+++ b/controller/controller_server/csi_controller_server.py
@@ -750,7 +750,7 @@ class ControllerServicer(csi_pb2_grpc.ControllerServicer):
         # controller_server.add_insecure_port('unix://{}'.format(self.server_port))
         controller_server.add_insecure_port(self.endpoint)
 
-        logger.info(f'Controller version: {self.__get_identity_config("version")}')
+        logger.info("Controller version: {}".format(self.__get_identity_config("version")))
 
         # start the server
         logger.debug("Listening for connections on endpoint address: {}".format(self.endpoint))

--- a/node/cmd/main.go
+++ b/node/cmd/main.go
@@ -25,6 +25,14 @@ import (
 	"github.com/ibm/ibm-block-csi-driver/node/pkg/driver"
 )
 
+func printVersion(configFile *string) {
+	info, err := driver.GetVersionJSON(*configFile)
+	if err != nil {
+		logger.Panicln(err)
+	}
+	logger.Infof(fmt.Sprintf("Node version: %v", info))
+}
+
 func main() {
 	logger.Debugf("Starting CSI node...") // Note - must set this in the first line in order to define the -loglevel in the flags
 	var (
@@ -36,12 +44,9 @@ func main() {
 
 	flag.Parse()
 
+	printVersion(configFile)
+
 	if *version {
-		info, err := driver.GetVersionJSON(*configFile)
-		if err != nil {
-			logger.Panicln(err)
-		}
-		fmt.Println(info)
 		os.Exit(0)
 	}
 

--- a/node/cmd/main.go
+++ b/node/cmd/main.go
@@ -36,17 +36,17 @@ func logVersionInfo(configFile *string) {
 func main() {
 	logger.Debugf("Starting CSI node...") // Note - must set this in the first line in order to define the -loglevel in the flags
 	var (
-		endpoint   = flag.String("csi-endpoint", "unix://csi/csi.sock", "CSI Endpoint")
-		version    = flag.Bool("version", false, "Print the version and exit.")
-		configFile = flag.String("config-file-path", "./config.yaml", "Shared config file.")
-		hostname   = flag.String("hostname", "host-dns-name", "The name of the host the node is running on.")
+		endpoint            = flag.String("csi-endpoint", "unix://csi/csi.sock", "CSI Endpoint")
+		exitAfterLogVersion = flag.Bool("version", false, "Log the version and exit.")
+		configFile          = flag.String("config-file-path", "./config.yaml", "Shared config file.")
+		hostname            = flag.String("hostname", "host-dns-name", "The name of the host the node is running on.")
 	)
 
 	flag.Parse()
 
 	logVersionInfo(configFile)
 
-	if *version {
+	if *exitAfterLogVersion {
 		os.Exit(0)
 	}
 

--- a/node/cmd/main.go
+++ b/node/cmd/main.go
@@ -25,12 +25,12 @@ import (
 	"github.com/ibm/ibm-block-csi-driver/node/pkg/driver"
 )
 
-func printVersion(configFile *string) {
+func logVersionInfo(configFile *string) {
 	info, err := driver.GetVersionJSON(*configFile)
 	if err != nil {
-		logger.Panicln(err)
+		logger.Errorln(err)
 	}
-	logger.Infof(fmt.Sprintf("Node version: %v", info))
+	logger.Infof(fmt.Sprintf("Node version info: %v", info))
 }
 
 func main() {
@@ -44,7 +44,7 @@ func main() {
 
 	flag.Parse()
 
-	printVersion(configFile)
+	logVersionInfo(configFile)
 
 	if *version {
 		os.Exit(0)


### PR DESCRIPTION
Controller:
`2021-04-11 20:23:33,916 INFO    [139949670514944] [MainThread] (csi_controller_server.py:start_server:753) - Controller version: 1.6.0`

Node:
`2021-04-11 20:21:57,4118 INFO   [1] [-] (main.go:33) - Node version: {
  "driverVersion": "1.6.0",
  "gitCommit": "fc3e67732bd318097aa31fabacd6791c79f729ed",
  "buildDate": "2021-04-11T20:16:09Z",
  "goVersion": "go1.12.6",
  "compiler": "gc",
  "platform": "linux/amd64"
}`
