### PR TITLE
avoid scl_enable print noise in CI

### DIFF
--- a/controller/scripts/unitests.sh
+++ b/controller/scripts/unitests.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -x
+#!/bin/bash
+set -x
 coveragedir=/driver/coverage/
 [ ! -d $coveragedir ] && mkdir -p $coveragedir
 exec nosetests --exe --with-coverage --cover-xml --cover-xml-file=$coveragedir/.coverage.xml --cover-package=common  --cover-package=controller --with-xunit --xunit-file=$coveragedir/.unitests.xml $@

--- a/controller/scripts/unitests.sh
+++ b/controller/scripts/unitests.sh
@@ -2,4 +2,4 @@
 set -x
 coveragedir=/driver/coverage/
 [ ! -d $coveragedir ] && mkdir -p $coveragedir
-exec nosetests --exe --with-coverage --cover-xml --cover-xml-file=$coveragedir/.coverage.xml --cover-package=common  --cover-package=controller --with-xunit --xunit-file=$coveragedir/.unitests.xml $@
+exec nosetests --exe --with-coverage --cover-xml --cover-xml-file=$coveragedir/.coverage.xml --cover-package=common --cover-package=controller --with-xunit --xunit-file=$coveragedir/.unitests.xml $@


### PR DESCRIPTION
remove:
```
+ unset BASH_ENV PROMPT_COMMAND ENV
+ grep -q '^CentOS Linux release 7'
+ head /etc/redhat-release
+ grep -q '^Red Hat Enterprise Linux\( Server\)\? release 7'
+ head /etc/redhat-release
+ source /opt/app-root/bin/activate
++ deactivate nondestructive
++ '[' -n '' ']'
++ '[' -n '' ']'
++ '[' -n /bin/bash -o -n '' ']'
++ hash -r
++ '[' -n '' ']'
++ unset VIRTUAL_ENV
++ '[' '!' nondestructive = nondestructive ']'
++ VIRTUAL_ENV=/opt/app-root
++ export VIRTUAL_ENV
++ _OLD_VIRTUAL_PATH=/opt/app-root/src/.local/bin/:/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++ PATH=/opt/app-root/bin:/opt/app-root/src/.local/bin/:/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++ export PATH
++ '[' -n '' ']'
++ '[' -z '' ']'
++ _OLD_VIRTUAL_PS1=
++ '[' 'x(app-root) ' '!=' x ']'
++ PS1='(app-root) '
++ export PS1
++ '[' -n /bin/bash -o -n '' ']'
++ hash -r
```
from `CSI-controller: Unit testing + coverage` output (as [was done](https://github.com/IBM/ibm-block-csi-driver/pull/256/commits/43068f467476754a731be801abd9e4a303888851) in other CI scripts)