### PR TITLE
disallow old openssl

### DIFF
--- a/Dockerfile-csi-controller
+++ b/Dockerfile-csi-controller
@@ -33,8 +33,6 @@ COPY controller/requirements.txt /driver/controller/
 RUN pip3 install --default-timeout=100 --upgrade pip==19.3.1
 # avoid default boringssl lib, since it does not support z systems
 ENV GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=True
-# TODO: remove CRYPTOGRAPHY_ALLOW_OPENSSL_102 when upgrading to ubi8
-ENV CRYPTOGRAPHY_ALLOW_OPENSSL_102=true
 ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
 RUN pip3 install -r /driver/controller/requirements.txt
 


### PR DESCRIPTION
missed in https://github.com/IBM/ibm-block-csi-driver/pull/271