### PR TITLE
CSI-2142 fix unstable mediator pool unit test

### DIFF
--- a/controller/tests/array_action/test_storage_agent.py
+++ b/controller/tests/array_action/test_storage_agent.py
@@ -1,5 +1,4 @@
 import unittest
-from queue import Queue
 from threading import Lock, Thread
 from time import sleep
 
@@ -244,8 +243,9 @@ class TestStorageAgent(unittest.TestCase):
                 with get_agent(ArrayConnectionInfo(array_addresses=["ds8k_host", ], user="test",
                                                    password="test")).get_mediator(timeout=timeout):
                     pass
-        else:
-            keep_alive_lock.release()
+
+        keep_alive_lock.release()
+        if not is_timeout:
             with get_agent(ArrayConnectionInfo(array_addresses=["ds8k_host", ], user="test",
                                                password="test")).get_mediator():
                 pass


### PR DESCRIPTION
the non-reviewed https://github.com/IBM/ibm-block-csi-driver/pull/170 has many issues, this fixes one of them:
a `sleep` does not guarantee that the desired state is always reached (in this case, that all remaining threads have created, and are still using, their mediator in the pool), no matter what hardcoded waiting time is chosen