### PR TITLE
CSI-4369 fix sg_inq timeout

### DIFF
--- a/node/pkg/driver/device_connectivity/device_connectivity_helper_scsigeneric.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_helper_scsigeneric.go
@@ -61,7 +61,7 @@ var (
 	TimeOutMultipathCmd  = 60 * 1000
 	TimeOutMultipathdCmd = 10 * 1000
 	TimeOutBlockDevCmd   = 10 * 1000
-	TimeOutSgInqCmd      = 3 * 1000
+	TimeOutSgInqCmd      = 10 * 1000
 )
 
 const (


### PR DESCRIPTION
it [seems](https://github.com/hreinecke/sg3_utils/blob/v1.46/src/sg_inq.c#L140) the internal timeout of the command is 60 seconds, IMO we can wait at least 10 seconds, in case there are network delays