### PR TITLE
Community tests - update go in container to 1.18

### DIFF
--- a/Dockerfile-csi-test
+++ b/Dockerfile-csi-test
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.16
+FROM golang:1.18
 
 ARG CSI_PARAMS=csi_params
 


### PR DESCRIPTION
Due to failing community tests - Needed to update go in the container to 1.18 in order to align with community code in go.mod