### PR TITLE
GetWwnByScsiInq: handle sg_inq v2.3x (sg3_utils 1.48+) output format change

### DIFF
--- a/node/pkg/driver/device_connectivity/device_connectivity_helper_scsigeneric.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_helper_scsigeneric.go
@@ -692,16 +692,52 @@ func (o OsDeviceConnectivityHelperGeneric) GetWwnByScsiInq(dev string) (string, 
 		return "", err
 	}
 
-	args := []string{"-p", "0x83", dev}
-	// add timeout in case the call never comes back.
-	logger.Debugf("Calling [%s] with timeout", sgInqCmd)
-	outputBytes, err := o.Executer.ExecuteWithTimeout(TimeOutSgInqCmd, sgInqCmd, args)
+	// sg_inq v2.3x (sg3_utils 1.48+) changed default output for -p 0x83 to raw hex.
+	// Try -i first because it keeps human-readable identification output across versions.
+	commandArgsList := [][]string{
+		{"-i", dev},
+		{"-p", "0x83", dev},
+	}
+	var parseErrors []string
+	var executionErrors []string
+	for _, args := range commandArgsList {
+		// add timeout in case the call never comes back.
+		logger.Debugf("Calling [%s %s] with timeout", sgInqCmd, strings.Join(args, " "))
+		outputBytes, err := o.Executer.ExecuteWithTimeout(TimeOutSgInqCmd, sgInqCmd, args)
+		if err != nil {
+			executionErrors = append(executionErrors, err.Error())
+			continue
+		}
+
+		wwn, err := o.getWwnFromScsiInqOutput(string(outputBytes), dev)
+		if err == nil {
+			return wwn, nil
+		}
+		parseErrors = append(parseErrors, err.Error())
+	}
+
+	if len(executionErrors) == len(commandArgsList) {
+		return "", errors.New(strings.Join(executionErrors, ","))
+	}
+	if len(executionErrors) > 0 {
+		allErrors := append(executionErrors, parseErrors...)
+		return "", fmt.Errorf("sg_inq failed for %s: %s", dev, strings.Join(allErrors, "; "))
+	}
+	if len(parseErrors) > 0 {
+		logger.Warningf("GetWwnByScsiInq: failed parsing sg_inq output for %s: %s", dev, strings.Join(parseErrors, ","))
+	}
+	return "", &MultipathDeviceNotFoundForVolumeError{dev}
+}
+
+func (o OsDeviceConnectivityHelperGeneric) getWwnFromScsiInqOutput(output string, dev string) (string, error) {
+	wwnBracketRegex := "(?i)" + `\[0x(.*?)\]`
+	wwnBracketRegexCompiled, err := regexp.Compile(wwnBracketRegex)
 	if err != nil {
 		return "", err
 	}
-	wwnRegex := "(?i)" + `\[0x(.*?)\]`
-	wwnRegexCompiled, err := regexp.Compile(wwnRegex)
-
+	// sg_inq v2.3x may output plain hex tokens without brackets.
+	wwnRawRegex := "(?i)" + `0x([[:xdigit:]]+)`
+	wwnRawRegexCompiled, err := regexp.Compile(wwnRawRegex)
 	if err != nil {
 		return "", err
 	}
@@ -710,7 +746,7 @@ func (o OsDeviceConnectivityHelperGeneric) GetWwnByScsiInq(dev string) (string, 
 	   sg_inq on device EUI-64 returns "Vendor Specific Extension Identifier".
 	*/
 	pattern := "(?i)" + "Vendor Specific (Identifier Extension|Extension Identifier):"
-	scanner := bufio.NewScanner(strings.NewReader(string(outputBytes[:])))
+	scanner := bufio.NewScanner(strings.NewReader(output))
 	regex, err := regexp.Compile(pattern)
 	if err != nil {
 		return "", err
@@ -720,12 +756,17 @@ func (o OsDeviceConnectivityHelperGeneric) GetWwnByScsiInq(dev string) (string, 
 	for scanner.Scan() {
 		line := scanner.Text()
 		if found {
-			matches := wwnRegexCompiled.FindStringSubmatch(line)
-			if len(matches) != 2 {
-				logger.Debugf("wrong line, too many matches in sg_inq output : %#v", matches)
-				return "", &ErrorNoRegexWwnMatchInScsiInq{dev, line}
+			matches := wwnBracketRegexCompiled.FindStringSubmatch(line)
+			if len(matches) == 2 {
+				wwn = matches[1]
+			} else {
+				matches = wwnRawRegexCompiled.FindStringSubmatch(line)
+				if len(matches) != 2 {
+					logger.Debugf("no wwn match in sg_inq output line: %q", line)
+					return "", &ErrorNoRegexWwnMatchInScsiInq{dev, line}
+				}
+				wwn = matches[1]
 			}
-			wwn = matches[1]
 			logger.Debugf("Found wwn [%s] in sg_inq", wwn)
 			return wwn, nil
 		}
@@ -736,7 +777,8 @@ func (o OsDeviceConnectivityHelperGeneric) GetWwnByScsiInq(dev string) (string, 
 		}
 
 	}
-	return "", &MultipathDeviceNotFoundForVolumeError{wwn}
+
+	return "", &MultipathDeviceNotFoundForVolumeError{dev}
 }
 
 func (o OsDeviceConnectivityHelperGeneric) ReloadMultipath() error {

--- a/node/pkg/driver/device_connectivity/device_connectivity_helper_scsigeneric_test.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_helper_scsigeneric_test.go
@@ -520,54 +520,107 @@ func TestHelperWaitForDmToExist(t *testing.T) {
 }
 
 func TestHelperGetWwnByScsiInq(t *testing.T) {
+	hexWwn := "6001738cfc9035eb0000000000ceaaaa"
 	testCases := []struct {
-		name            string
-		cmdReturn       []byte
-		expErr          error
-		wwn             string
-		cmdReturnErr    error
-		sgInqExecutable error
-		expErrType      reflect.Type
+		name              string
+		inquiryCmdReturn  []byte
+		inquiryCmdErr     error
+		vpdCmdReturn      []byte
+		vpdCmdErr         error
+		expErr            error
+		wwn               string
+		sgInqExecutable   error
+		expErrType        reflect.Type
+		expectVpdFallback bool
 	}{
 		{
-			name:            "Should fail when sg_Inq is not executable",
-			cmdReturn:       []byte(""),
-			wwn:             "",
-			cmdReturnErr:    nil,
-			expErr:          fmt.Errorf("error"),
-			sgInqExecutable: fmt.Errorf("error"),
+			name:             "Should fail when sg_Inq is not executable",
+			inquiryCmdReturn: []byte(""),
+			wwn:              "",
+			inquiryCmdErr:    nil,
+			expErr:           fmt.Errorf("error"),
+			sgInqExecutable:  fmt.Errorf("error"),
 		},
 		{
-			name:            "Should fail when cmd return error",
-			cmdReturn:       []byte(""),
-			wwn:             "",
-			cmdReturnErr:    fmt.Errorf("error"),
-			expErr:          fmt.Errorf("error"),
-			sgInqExecutable: nil,
+			name:              "Should fail when both commands return error",
+			inquiryCmdReturn:  []byte(""),
+			wwn:               "",
+			inquiryCmdErr:     fmt.Errorf("error"),
+			vpdCmdErr:         fmt.Errorf("error"),
+			expErr:            errors.New("error,error"),
+			sgInqExecutable:   nil,
+			expectVpdFallback: true,
 		},
 		{
-			name:            "Should return error when wwn line not matching the expected pattern",
-			cmdReturn:       []byte(fmt.Sprintf("Vendor Specific Identifier Extension: 0xcea5f6\n\t\t\t  [%s]", volumeUuid)),
-			wwn:             "",
-			cmdReturnErr:    nil,
-			expErrType:      reflect.TypeOf(&device_connectivity.ErrorNoRegexWwnMatchInScsiInq{}),
-			sgInqExecutable: nil,
+			name:              "Should fail when no device found",
+			inquiryCmdReturn:  []byte(""),
+			vpdCmdReturn:      []byte(""),
+			wwn:               "",
+			inquiryCmdErr:     nil,
+			vpdCmdErr:         nil,
+			expErrType:        reflect.TypeOf(&device_connectivity.MultipathDeviceNotFoundForVolumeError{}),
+			sgInqExecutable:   nil,
+			expectVpdFallback: true,
 		},
 		{
-			name:            "Should fail when no device found",
-			cmdReturn:       []byte(""),
-			wwn:             "",
-			cmdReturnErr:    nil,
-			expErrType:      reflect.TypeOf(&device_connectivity.MultipathDeviceNotFoundForVolumeError{}),
-			sgInqExecutable: nil,
+			name:             "Should succeed with sg_inq -i output",
+			inquiryCmdReturn: []byte(fmt.Sprintf("Vendor Specific Identifier Extension: 0xcea5f6\n\t\t\t  [0x%s]", volumeUuid)),
+			wwn:              volumeUuid,
+			inquiryCmdErr:    nil,
+			expErr:           nil,
+			sgInqExecutable:  nil,
 		},
 		{
-			name:            "Should succeed",
-			cmdReturn:       []byte(fmt.Sprintf("Vendor Specific Identifier Extension: 0xcea5f6\n\t\t\t  [0x%s]", volumeUuid)),
-			wwn:             volumeUuid,
-			cmdReturnErr:    nil,
+			name:              "Should fallback to sg_inq -p 0x83 when -i output is not parseable",
+			inquiryCmdReturn:  []byte("non parseable output"),
+			vpdCmdReturn:      []byte(fmt.Sprintf("Vendor Specific Identifier Extension: 0xcea5f6\n\t\t\t  [0x%s]", volumeUuid)),
+			wwn:               volumeUuid,
+			inquiryCmdErr:     nil,
+			vpdCmdErr:         nil,
+			expErr:            nil,
+			sgInqExecutable:   nil,
+			expectVpdFallback: true,
+		},
+		{
+			name: "Should succeed with sg_inq v2.3x raw hex output (no brackets)",
+			inquiryCmdReturn: []byte(fmt.Sprintf(
+				"Vendor Specific Identifier Extension: 0xcea5f6\n\t\t\t  0x%s", hexWwn)),
+			wwn:             hexWwn,
+			inquiryCmdErr:   nil,
 			expErr:          nil,
 			sgInqExecutable: nil,
+		},
+		{
+			name: "Should succeed with EUI-64 sg_inq v2.3x raw hex output (no brackets)",
+			inquiryCmdReturn: []byte(fmt.Sprintf(
+				"Vendor Specific Extension Identifier: 0xcea5f6\n\t\t\t  0x%s", hexWwn)),
+			wwn:             hexWwn,
+			inquiryCmdErr:   nil,
+			expErr:          nil,
+			sgInqExecutable: nil,
+		},
+		{
+			name:              "Should succeed when -i execution fails but -p 0x83 succeeds",
+			inquiryCmdReturn:  []byte(""),
+			inquiryCmdErr:     fmt.Errorf("error"),
+			vpdCmdReturn:      []byte(fmt.Sprintf("Vendor Specific Identifier Extension: 0xcea5f6\n\t\t\t  [0x%s]", volumeUuid)),
+			vpdCmdErr:         nil,
+			wwn:               volumeUuid,
+			expErr:            nil,
+			sgInqExecutable:   nil,
+			expectVpdFallback: true,
+		},
+		{
+			name:             "Should surface execution error in mixed parse+exec failure",
+			inquiryCmdReturn: []byte("non parseable output"),
+			inquiryCmdErr:    nil,
+			vpdCmdErr:        fmt.Errorf("exec_error"),
+			wwn:              "",
+			expErr: fmt.Errorf("sg_inq failed for /dev/dm-1: exec_error; " +
+				"Couldn't find multipath device for volumeID [/dev/dm-1]. " +
+				"Please check the host connectivity to the storage."),
+			sgInqExecutable:   nil,
+			expectVpdFallback: true,
 		},
 	}
 	sgInqCmd := "sg_inq"
@@ -579,11 +632,15 @@ func TestHelperGetWwnByScsiInq(t *testing.T) {
 			defer mockCtrl.Finish()
 
 			fakeExecuter := mocks.NewMockExecuterInterface(mockCtrl)
-			args := []string{"-p", "0x83", device}
+			inquiryArgs := []string{"-i", device}
+			vpdArgs := []string{"-p", "0x83", device}
 			fakeExecuter.EXPECT().IsExecutable(sgInqCmd).Return(tc.sgInqExecutable)
 
 			if tc.sgInqExecutable == nil {
-				fakeExecuter.EXPECT().ExecuteWithTimeout(device_connectivity.TimeOutSgInqCmd, sgInqCmd, args).Return(tc.cmdReturn, tc.cmdReturnErr)
+				fakeExecuter.EXPECT().ExecuteWithTimeout(device_connectivity.TimeOutSgInqCmd, sgInqCmd, inquiryArgs).Return(tc.inquiryCmdReturn, tc.inquiryCmdErr)
+				if tc.expectVpdFallback {
+					fakeExecuter.EXPECT().ExecuteWithTimeout(device_connectivity.TimeOutSgInqCmd, sgInqCmd, vpdArgs).Return(tc.vpdCmdReturn, tc.vpdCmdErr)
+				}
 			}
 
 			helperGeneric := device_connectivity.NewOsDeviceConnectivityHelperGeneric(fakeExecuter)


### PR DESCRIPTION
## Problem

`sg3_utils 1.48+` changed `sg_inq -p 0x83` to output raw hex bytes instead of the decoded Device Identification VPD page. This breaks `GetWwnByScsiInq` the driver extracts an empty WWN, `NodeStageVolume` fails, and volumes never mount.

Reproduced on:
- SUSE Linux Micro 6.1 (sg_inq v2.32, sg3_utils 1.48)
- Harvester 1.7.1
- Debian Trixie (sg_inq v2.48, sg3_utils 1.48)
- OKD 4.20 / CentOS 10

The actual output on affected systems for `sg_inq -p 0x83 /dev/dm-X`:

```
VPD INQUIRY, page code=0x83:
00 00 83 00 24 01 03 00 10 60 05 07 68 10 81 05 ab
10 58 00 00 00 00 00 00 37 01 94 00 04 00 00 0e 86
20 01 95 00 04 00 00 00 11
```

The driver expected the decoded text output with `[0x<wwn>]` brackets, which no longer appears.

## Fix

- Try `sg_inq -i` first. The `-i`/`--id` flag produces the decoded Device Identification output (with bracketed WWN) on **all** sg_inq versions — it has existed since at least sg3_utils 1.42.
- Fall back to `sg_inq -p 0x83` if `-i` fails to execute or its output is unparseable.
- Add a secondary `0x<hex>` regex (without brackets) on the WWN line as defense for any future format variants.
- Surface execution errors properly in mixed failure scenarios (e.g. `-i` output unparseable + `-p 0x83` times out) instead of returning a misleading `MultipathDeviceNotFoundForVolumeError`.
- Extract parsing into `getWwnFromScsiInqOutput()` for testability.

## Tests

- `sg_inq -i` success (bracketed WWN) — NAA6 and EUI-64
- `sg_inq -i` raw hex output (no brackets) — NAA6 and EUI-64
- `-i` output unparseable → fallback to `-p 0x83` succeeds
- `-i` execution failure → `-p 0x83` succeeds
- Both commands fail to execute → combined error
- Empty output from both → `MultipathDeviceNotFoundForVolumeError`
- Mixed parse + execution failure → surfaces execution error, not device-not-found

## Backwards compatibility

On older sg3_utils (< 1.48), `sg_inq -i` produces the same decoded output that `-p 0x83` used to. The driver will parse it via the existing bracket regex on the first attempt. The `-p 0x83` fallback is never reached in the happy path no behavior change for working environments.

Fixes #850
Fixes #824