### PR TITLE
Fix CSI-6190: UT failures on s390x and stabilize CSI component Jenkins job

### DIFF
--- a/Dockerfile-controllers.test
+++ b/Dockerfile-controllers.test
@@ -19,8 +19,12 @@
 FROM registry.access.redhat.com/ubi9/python-312:1-1778473732 AS builder
 USER root
 RUN if [[ "$(uname -m)" != "x86"* ]]; then yum install -y rust-toolset; fi
+
 USER default
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+RUN if [[ "$(uname -m)" == "s390x" ]]; then \
+    export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python; \
+    fi
 WORKDIR /tmp
 COPY controllers/servers/csi/requirements.txt ./csi_requirements.txt
 COPY controllers/servers/csi/requirements_pyxcli.txt ./csi_requirements_pyxcli.txt
@@ -42,15 +46,23 @@ RUN pip3 install -r ./requirements-tests.txt
 
 FROM registry.access.redhat.com/ubi9/python-312:1-1778473732
 
+RUN if [[ "$(uname -m)" == "s390x" ]]; then \
+    export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python; \
+    fi
+
 COPY --from=builder /opt/app-root /opt/app-root
 COPY ./common /driver/common
 COPY ./controllers/ /driver/controllers/
+
 USER root
 RUN groupadd -g 9999 appuser && \
     useradd -r -u 9999 -g appuser appuser
+
 RUN chown -R appuser:appuser /driver /opt/app-root
+
 USER appuser
 WORKDIR /driver
+
 ENV PYTHONPATH=/driver
 
 ENTRYPOINT ["/driver/controllers/scripts/entrypoint-test.sh"]

--- a/controllers/scripts/entrypoint-test.sh
+++ b/controllers/scripts/entrypoint-test.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+if [[ "$(uname -m)" == "s390x" ]]; then \
+  export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+  fi
 ./controllers/scripts/pycodestyle.sh
 PYCODESTYLE=$?
 

--- a/controllers/servers/csi/requirements.txt
+++ b/controllers/servers/csi/requirements.txt
@@ -2,7 +2,8 @@ pip==26.1.1
 wheel==0.46.2
 grpcio==1.74.0
 grpcio-tools==1.74.0
-protobuf==6.33.5
+protobuf==6.33.5; platform_machine == "x86_64"
+protobuf==6.31.1; platform_machine != "x86_64"
 pyyaml==6.0.2
 munch==4.0.0
 retry2==0.9.5


### PR DESCRIPTION
Fix CSI-6190: UT failures on s390x and stabilize CSI component Jenkins job
    1. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python for compatibility
    2. Update requirements and test environment setup