### PR TITLE
feat(node): native NVMe/FC ANA multipath support (discovery, stage/publish/expand/stats, path accounting)

### DIFF
--- a/node/pkg/driver/device_connectivity/device_connectivity_helper_scsigeneric.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_helper_scsigeneric.go
@@ -110,6 +110,12 @@ func (r OsDeviceConnectivityHelperScsiGeneric) IsVolumePathMatchesVolumeId(volum
 		return false, err
 	}
 
+	// Native NVMe multipath has no dm device; confirm the mounted namespace head matches
+	// the volume by its sysfs NGUID instead of querying multipathd.
+	if native, nerr := IsNvmeCoreMultipathEnabled(r.Executer); nerr == nil && native {
+		return r.isNativeVolumePathMatch(mpathDeviceName, volumeIdVariations), nil
+	}
+
 	dmDirectory := DevPath
 	multipathdCommandFormatArgs := multipathdWildcardsMpathAndVolumeId
 	if r.Helper.IsDmName(mpathDeviceName) {
@@ -129,6 +135,28 @@ func (r OsDeviceConnectivityHelperScsiGeneric) IsVolumePathMatchesVolumeId(volum
 
 	logger.Infof("IsVolumePathMatchesVolumeId: found volume id [%s] for volume path [%s] ", mpathVolumeId, volumePath)
 	return r.Helper.IsAnyVariationInMpathVolumeId(mpathVolumeId, volumeIdVariations), nil
+}
+
+// isNativeVolumePathMatch confirms a mounted native NVMe namespace head matches the
+// volume by comparing its sysfs wwid (NGUID) to the volume id variations. Returns false
+// (not an error) when the device is gone or the id does not match, so the caller reports
+// NotFound rather than Internal.
+func (r OsDeviceConnectivityHelperScsiGeneric) isNativeVolumePathMatch(deviceName string, volumeIdVariations []string) bool {
+	wwidPath := filepath.Join("/sys/block", deviceName, "wwid")
+	data, err := r.Executer.IoutilReadFile(wwidPath)
+	if err != nil {
+		logger.Warningf("isNativeVolumePathMatch: cannot read %s: %v", wwidPath, err)
+		return false
+	}
+	normalized := normalizeNguid(string(data))
+	for _, variation := range volumeIdVariations {
+		if normalized == variation {
+			return true
+		}
+	}
+	logger.Infof("isNativeVolumePathMatch: device %s nguid [%s] does not match volume variations %v",
+		deviceName, normalized, volumeIdVariations)
+	return false
 }
 
 func (r OsDeviceConnectivityHelperScsiGeneric) RescanDevicesGetHostIds(lunId int, arrayIdentifiers []string) (map[int]bool, error) {

--- a/node/pkg/driver/device_connectivity/device_connectivity_helper_scsigeneric.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_helper_scsigeneric.go
@@ -187,8 +187,13 @@ func (r OsDeviceConnectivityHelperScsiGeneric) RescanDevices(lunId int, arrayIde
 	return nil
 }
 
-func isNvmeCoreMultipathEnabled() (bool, error) {
-	data, err := os.ReadFile(nvmeCoreMultipathParamPath)
+// IsNvmeCoreMultipathEnabled reports whether the kernel runs native NVMe multipath
+// (nvme_core.multipath=Y) vs dm-multipath (=N). The read is routed through the
+// Executer so it can be faked in unit tests. A missing param file (nvme_core not
+// loaded) is treated as "not native". Single source of truth for mode detection —
+// callers in both the device_connectivity and driver packages delegate here.
+func IsNvmeCoreMultipathEnabled(exec executer.ExecuterInterface) (bool, error) {
+	data, err := exec.IoutilReadFile(nvmeCoreMultipathParamPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
@@ -252,7 +257,7 @@ func isNonNativeNvmeDevice(dmPath string, executer executer.ExecuterInterface) b
 }
 
 func isNvmeDevice(dmPath string, executer executer.ExecuterInterface) bool {
-	nativeMpath, err := isNvmeCoreMultipathEnabled()
+	nativeMpath, err := IsNvmeCoreMultipathEnabled(executer)
 
 	if err != nil {
 		logger.Warningf("isNvmeDevice: could not read nvme_core param: %v, trying both checks", err)

--- a/node/pkg/driver/device_connectivity/device_connectivity_helper_scsigeneric_test.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_helper_scsigeneric_test.go
@@ -226,6 +226,10 @@ func TestGetMpathDevice(t *testing.T) {
 				"nvme",
 				[]string{"list"},
 			).Return([]byte(""), nil).AnyTimes()
+			// Mode detection now reads nvme_core/parameters/multipath via the Executer;
+			// return "N" (dm-multipath) so isNvmeDevice takes the non-native check path.
+			fakeExecuter.EXPECT().IoutilReadFile("/sys/module/nvme_core/parameters/multipath").
+				Return([]byte("N"), nil).AnyTimes()
 			fake_helper := mocks.NewMockOsDeviceConnectivityHelperInterface(mockCtrl)
 			fake_mutex := &sync.Mutex{}
 			volumeIdVariations := []string{volumeUuid, volumeNguid}

--- a/node/pkg/driver/device_connectivity/device_connectivity_helper_scsigeneric_test.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_helper_scsigeneric_test.go
@@ -1000,6 +1000,9 @@ func TestIsVolumePathMatchesVolumeId(t *testing.T) {
 			fakeExecuter := mocks.NewMockExecuterInterface(mockCtrl)
 			o := NewOsDeviceConnectivityHelperScsiGenericForTest(fakeExecuter, mockOsDeviceConHelper, nil)
 
+			// dm-multipath mode: the native NGUID match path is not taken.
+			fakeExecuter.EXPECT().IoutilReadFile("/sys/module/nvme_core/parameters/multipath").
+				Return([]byte("N"), nil).AnyTimes()
 			mockOsDeviceConHelper.EXPECT().GetVolumeIdVariations(tc.volumeUuid).Return(volumeIdVariations)
 			mockOsDeviceConHelper.EXPECT().GetMpathDeviceName(tc.volumePath).Return(tc.mpathDeviceName, tc.mpathDeviceNameErr)
 			if tc.mpathDeviceName != "" {

--- a/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc.go
@@ -334,8 +334,93 @@ func (r OsDeviceConnectivityNvmeOFc) getHostFCPorts() ([]string, error) {
 	return hostPorts, nil
 }
 
-func (r OsDeviceConnectivityNvmeOFc) RescanDevices(_ int, _ []string) error {
+// RescanDevices forces an NVMe namespace rescan on the array's already-connected
+// controllers. nvme connect to an existing controller is a no-op and does not
+// re-enumerate namespaces, so a LUN mapped after the controller was established
+// only appears via a kernel AEN auto-rescan. When that AEN is missed, staging
+// cannot discover the namespace. This mirrors the manual `nvme ns-rescan` recovery:
+// it enumerates the controllers whose traddr matches the array target ports and
+// rescans each, so a missed-AEN namespace becomes visible before GetMpathDevice.
+//
+// Best-effort and non-fatal by design: a rescan that finds nothing (or a transient
+// per-controller failure) must not fail the stage — GetMpathDevice retries after,
+// and the AEN may already have landed. arrayIdentifiers are the array target ports
+// ("nn-WWNN:pn-WWPN"); lunId (NSID) is unused — all namespaces on the array
+// controllers are rescanned, matching the proven manual recovery.
+func (r OsDeviceConnectivityNvmeOFc) RescanDevices(_ int, arrayIdentifiers []string) error {
+	if len(arrayIdentifiers) == 0 {
+		logger.Warningf("NVMe-oFC RescanDevices: no array target ports provided, skipping namespace rescan")
+		return nil
+	}
+
+	controllers := r.getArrayControllers(arrayIdentifiers)
+	if len(controllers) == 0 {
+		logger.Warningf("NVMe-oFC RescanDevices: no connected controllers matched array targets %v, "+
+			"skipping namespace rescan", arrayIdentifiers)
+		return nil
+	}
+
+	for _, controller := range controllers {
+		devicePath := "/dev/" + controller
+		logger.Infof("NVMe-oFC RescanDevices: rescanning namespaces on controller %s", devicePath)
+		if out, err := r.Executer.ExecuteWithTimeout(nvmeCmdTimeout, "nvme", []string{"ns-rescan", devicePath}); err != nil {
+			// Non-fatal: log and continue; GetMpathDevice retries discovery afterwards.
+			logger.Warningf("NVMe-oFC RescanDevices: ns-rescan failed on %s: %v output=%s",
+				devicePath, err, string(out))
+			continue
+		}
+	}
 	return nil
+}
+
+// getArrayControllers parses "nvme list-subsys" and returns the controller device
+// names (e.g. "nvme0") whose traddr matches one of the array target ports. Only the
+// array's controllers are rescanned so the local boot NVMe and unrelated subsystems
+// are left untouched.
+func (r OsDeviceConnectivityNvmeOFc) getArrayControllers(arrayIdentifiers []string) []string {
+	arrayTraddrs := make(map[string]bool, len(arrayIdentifiers))
+	for _, id := range arrayIdentifiers {
+		arrayTraddrs[normalizeTraddr(id)] = true
+	}
+
+	out, err := r.Executer.ExecuteWithTimeout(nvmeCmdTimeout, "nvme", []string{"list-subsys"})
+	if err != nil {
+		logger.Warningf("NVMe-oFC getArrayControllers: nvme list-subsys failed: %v", err)
+		return nil
+	}
+
+	seen := map[string]bool{}
+	var controllers []string
+	for _, line := range strings.Split(string(out), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "+-") {
+			continue
+		}
+		fields := strings.Fields(trimmed)
+		// Expected: "+- nvme0 fc traddr=... host_traddr=... live"
+		if len(fields) < 2 {
+			continue
+		}
+		controller := fields[1]
+		traddr := normalizeTraddr(extractNvmeField(trimmed, "traddr="))
+		if traddr == "" || !arrayTraddrs[traddr] {
+			continue
+		}
+		if seen[controller] {
+			continue
+		}
+		seen[controller] = true
+		controllers = append(controllers, controller)
+		logger.Debugf("NVMe-oFC getArrayControllers: matched controller=%s traddr=%s", controller, traddr)
+	}
+	return controllers
+}
+
+// normalizeTraddr lowercases and strips "0x" so target ports from the publish
+// context ("nn-500...:pn-500...") match list-subsys traddrs regardless of whether
+// the kernel emits the hex "0x" prefix.
+func normalizeTraddr(traddr string) string {
+	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(traddr)), "0x", "")
 }
 
 func (r OsDeviceConnectivityNvmeOFc) GetMpathDevice(volumeId string) (string, error) {

--- a/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc.go
@@ -39,6 +39,11 @@ const (
 	// is exactly what convertScsiIdToNguid derives from the SCSI volume UID.
 	nvmeByIdEuiPrefix    = "/dev/disk/by-id/nvme-eui."
 	sysBlockNvmeWwidGlob = "/sys/block/nvme*/wwid"
+	// sysClassNvmeSubsysNqnGlob enumerates every NVMe controller's subsystem NQN;
+	// sysBlockDeviceSubsysNqnFmt reads a namespace head's subsystem NQN via its
+	// device link. Used to find which controllers carry a given namespace for rescan.
+	sysClassNvmeSubsysNqnGlob  = "/sys/class/nvme/nvme*/subsysnqn"
+	sysBlockDeviceSubsysNqnFmt = "/sys/block/%s/device/subsysnqn"
 )
 
 type OsDeviceConnectivityNvmeOFc struct {
@@ -507,6 +512,60 @@ func normalizeNguid(s string) string {
 	s = strings.TrimPrefix(s, "eui.")
 	s = strings.TrimPrefix(s, "nguid.")
 	return strings.ReplaceAll(s, "-", "")
+}
+
+// RescanNvmeNamespaceForResize triggers an NVMe controller rescan so the kernel re-reads
+// a namespace's size after an array-side expand. Native multipath emits no dm device to
+// resize, and the size only refreshes via a kernel AEN or an explicit rescan; without one
+// the filesystem grow reads a stale size and under-expands. Rescans the controllers of the
+// namespace head's subsystem (matched by subsysnqn, so unrelated subsystems are left
+// alone). Best-effort: a missing subsysnqn or a per-controller failure is logged, not
+// fatal — the subsequent grow still runs against whatever size the kernel reports.
+func RescanNvmeNamespaceForResize(exec executer.ExecuterInterface, namespaceDevice string) error {
+	subsysNqnPath := fmt.Sprintf(sysBlockDeviceSubsysNqnFmt, namespaceDevice)
+	data, err := exec.IoutilReadFile(subsysNqnPath)
+	if err != nil {
+		logger.Warningf("RescanNvmeNamespaceForResize: cannot read %s: %v; relying on kernel AEN", subsysNqnPath, err)
+		return nil
+	}
+	subsysNqn := strings.TrimSpace(string(data))
+
+	controllers := findControllersBySubsysNqn(exec, subsysNqn)
+	if len(controllers) == 0 {
+		logger.Warningf("RescanNvmeNamespaceForResize: no controllers found for subsysnqn %s; relying on kernel AEN", subsysNqn)
+		return nil
+	}
+
+	for _, controller := range controllers {
+		devicePath := "/dev/" + controller
+		logger.Infof("RescanNvmeNamespaceForResize: rescanning %s to refresh namespace %s size", devicePath, namespaceDevice)
+		if out, err := exec.ExecuteWithTimeout(nvmeCmdTimeout, "nvme", []string{"ns-rescan", devicePath}); err != nil {
+			logger.Warningf("RescanNvmeNamespaceForResize: ns-rescan failed on %s: %v output=%s", devicePath, err, string(out))
+		}
+	}
+	return nil
+}
+
+// findControllersBySubsysNqn returns the NVMe controller names (e.g. "nvme1") whose
+// subsystem NQN equals targetNqn.
+func findControllersBySubsysNqn(exec executer.ExecuterInterface, targetNqn string) []string {
+	matches, err := exec.FilepathGlob(sysClassNvmeSubsysNqnGlob)
+	if err != nil {
+		logger.Warningf("findControllersBySubsysNqn: glob %s failed: %v", sysClassNvmeSubsysNqnGlob, err)
+		return nil
+	}
+	var controllers []string
+	for _, nqnPath := range matches {
+		data, err := exec.IoutilReadFile(nqnPath)
+		if err != nil {
+			continue
+		}
+		if strings.TrimSpace(string(data)) == targetNqn {
+			// nqnPath = /sys/class/nvme/<ctrl>/subsysnqn → controller is the parent dir.
+			controllers = append(controllers, filepath.Base(filepath.Dir(nqnPath)))
+		}
+	}
+	return controllers
 }
 
 func (r OsDeviceConnectivityNvmeOFc) FlushMultipathDevice(mpathDevice string) error {

--- a/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc.go
@@ -128,7 +128,7 @@ func (r OsDeviceConnectivityNvmeOFc) EnsureLogin(ipsByArrayInitiator map[string]
 
 	// Non-native NVMe + find_multipaths=on + < 2 paths: multipathd will not
 	// create a dm device, causing GetMpathDevice to fail.
-	nativeMpath, err := isNvmeCoreMultipathEnabled()
+	nativeMpath, err := IsNvmeCoreMultipathEnabled(r.Executer)
 	if err != nil {
 		logger.Warningf("NVMe-oFC EnsureLogin: could not determine nvme_core multipath mode: %v", err)
 		return

--- a/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc.go
@@ -443,55 +443,56 @@ func (r OsDeviceConnectivityNvmeOFc) GetMpathDevice(volumeId string) (string, er
 		logger.Warningf("NVMe-oFC GetMpathDevice: could not determine multipath mode: %v; using dm discovery", err)
 	}
 	if native {
-		return r.discoverNativeNamespace(volumeId)
+		return DiscoverNativeNamespaceDevice(r.Executer, volumeId)
 	}
 	return r.HelperScsiGeneric.GetMpathDevice(volumeId)
 }
 
-// discoverNativeNamespace finds the ANA namespace-head device for the volume by its
-// NGUID, retrying briefly while udev settles after the ns-rescan done in RescanDevices
-// (mirrors the dm path's "wait for dm to exist"). Returns the same
-// MultipathDeviceNotFoundForVolumeError as the dm path when nothing is found, so
-// callers (e.g. idempotent NodeUnstage) behave identically across modes.
-func (r OsDeviceConnectivityNvmeOFc) discoverNativeNamespace(volumeId string) (string, error) {
+// DiscoverNativeNamespaceDevice finds the ANA namespace-head device for the volume by
+// its NGUID, retrying briefly while udev settles after the ns-rescan done in
+// RescanDevices (mirrors the dm path's "wait for dm to exist"). Returns the same
+// MultipathDeviceNotFoundForVolumeError as the dm path when nothing is found, so callers
+// (e.g. idempotent NodeUnstage) behave identically across modes. Exported so node-level
+// callers without a connectivity dispatch (NodeGetVolumeStats block path) can reuse it.
+func DiscoverNativeNamespaceDevice(exec executer.ExecuterInterface, volumeId string) (string, error) {
 	nguid := convertScsiIdToNguid(strings.ToLower(volumeId))
-	logger.Infof("NVMe-oFC discoverNativeNamespace: resolving native NVMe head for volume %s (nguid=%s)", volumeId, nguid)
+	logger.Infof("DiscoverNativeNamespaceDevice: resolving native NVMe head for volume %s (nguid=%s)", volumeId, nguid)
 	for i := 0; i < WaitForMpathRetries; i++ {
-		if device := r.resolveNativeNamespaceOnce(nguid); device != "" {
-			logger.Infof("NVMe-oFC discoverNativeNamespace: resolved volume %s to %s", volumeId, device)
+		if device := resolveNativeNamespaceOnce(exec, nguid); device != "" {
+			logger.Infof("DiscoverNativeNamespaceDevice: resolved volume %s to %s", volumeId, device)
 			return device, nil
 		}
 		time.Sleep(time.Second * time.Duration(WaitForMpathWaitIntervalSec))
 	}
-	logger.Errorf("NVMe-oFC discoverNativeNamespace: no native NVMe namespace for volume %s (nguid=%s)", volumeId, nguid)
+	logger.Errorf("DiscoverNativeNamespaceDevice: no native NVMe namespace for volume %s (nguid=%s)", volumeId, nguid)
 	return "", &MultipathDeviceNotFoundForVolumeError{volumeId}
 }
 
 // resolveNativeNamespaceOnce does one lookup: first the stable by-id symlink
 // /dev/disk/by-id/nvme-eui.<nguid>, then a sysfs scan of /sys/block/nvme*/wwid (in case
 // the udev symlink lags the rescan). Returns "" if the namespace is not yet present.
-func (r OsDeviceConnectivityNvmeOFc) resolveNativeNamespaceOnce(nguid string) string {
+func resolveNativeNamespaceOnce(exec executer.ExecuterInterface, nguid string) string {
 	byIdPath := nvmeByIdEuiPrefix + nguid
-	if target, err := r.Executer.OsReadlink(byIdPath); err == nil && target != "" {
+	if target, err := exec.OsReadlink(byIdPath); err == nil && target != "" {
 		device := filepath.Join(DevPath, filepath.Base(target))
-		logger.Debugf("NVMe-oFC resolveNativeNamespaceOnce: %s -> %s", byIdPath, device)
+		logger.Debugf("resolveNativeNamespaceOnce: %s -> %s", byIdPath, device)
 		return device
 	}
 
-	matches, err := r.Executer.FilepathGlob(sysBlockNvmeWwidGlob)
+	matches, err := exec.FilepathGlob(sysBlockNvmeWwidGlob)
 	if err != nil {
-		logger.Warningf("NVMe-oFC resolveNativeNamespaceOnce: glob %s failed: %v", sysBlockNvmeWwidGlob, err)
+		logger.Warningf("resolveNativeNamespaceOnce: glob %s failed: %v", sysBlockNvmeWwidGlob, err)
 		return ""
 	}
 	for _, wwidPath := range matches {
-		data, err := r.Executer.IoutilReadFile(wwidPath)
+		data, err := exec.IoutilReadFile(wwidPath)
 		if err != nil {
 			continue
 		}
 		if normalizeNguid(string(data)) == nguid {
 			// wwidPath = /sys/block/<dev>/wwid → the device name is the parent dir.
 			device := filepath.Join(DevPath, filepath.Base(filepath.Dir(wwidPath)))
-			logger.Debugf("NVMe-oFC resolveNativeNamespaceOnce: sysfs %s matched -> %s", wwidPath, device)
+			logger.Debugf("resolveNativeNamespaceOnce: sysfs %s matched -> %s", wwidPath, device)
 			return device
 		}
 	}

--- a/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc.go
@@ -96,7 +96,7 @@ func (r OsDeviceConnectivityNvmeOFc) EnsureLogin(ipsByArrayInitiator map[string]
 				break
 			}
 
-			pathKey := arrayTargetPort + "|" + hostPort
+			pathKey := normalizeTraddr(arrayTargetPort) + "|" + normalizeTraddr(hostPort)
 			if livePaths[pathKey] {
 				logger.Debugf("NVMe-oFC EnsureLogin: path already live target=%s host=%s, skipping",
 					arrayTargetPort, hostPort)
@@ -161,15 +161,21 @@ func (r OsDeviceConnectivityNvmeOFc) EnsureLogin(ipsByArrayInitiator map[string]
 	}
 }
 
-// countLivePathsForSubsystem counts live paths whose traddr matches one of our array target ports.
+// countLivePathsForSubsystem counts live paths whose traddr matches one of our array
+// target ports. Both sides are normalized (strip "0x", lowercase) because the kernel's
+// list-subsys output carries a "0x" prefix the publish-context targets lack.
 func countLivePathsForSubsystem(livePaths map[string]bool, ipsByArrayInitiator map[string][]string) int {
+	arrayTargets := make(map[string]bool, len(ipsByArrayInitiator))
+	for target := range ipsByArrayInitiator {
+		arrayTargets[normalizeTraddr(target)] = true
+	}
 	count := 0
 	for pathKey := range livePaths {
 		parts := strings.SplitN(pathKey, "|", 2)
 		if len(parts) != 2 {
 			continue
 		}
-		if _, ok := ipsByArrayInitiator[parts[0]]; ok {
+		if arrayTargets[normalizeTraddr(parts[0])] {
 			count++
 		}
 	}
@@ -217,7 +223,9 @@ func (r OsDeviceConnectivityNvmeOFc) getLivePathPairs() map[string]bool {
 		traddr := extractNvmeField(trimmed, "traddr=")
 		hostTraddr := extractNvmeField(trimmed, "host_traddr=")
 		if traddr != "" && hostTraddr != "" {
-			livePaths[traddr+"|"+hostTraddr] = true
+			// The kernel emits addresses with a "0x" hex prefix; the publish-context
+			// array targets and sysfs host ports do not. Normalize so the keys compare.
+			livePaths[normalizeTraddr(traddr)+"|"+normalizeTraddr(hostTraddr)] = true
 			logger.Debugf("NVMe-oFC getLivePathPairs: live path traddr=%s host_traddr=%s", traddr, hostTraddr)
 		}
 	}
@@ -295,6 +303,13 @@ func (r OsDeviceConnectivityNvmeOFc) nvmeConnect(arrayTargetPort, hostPort, subN
 	}
 	out, err := r.Executer.ExecuteWithTimeout(nvmeCmdTimeout, "nvme", args)
 	if err != nil {
+		// "already connected" is the steady state when host autoconnect brought the
+		// path up (the norm in native mode) — the path IS live, so count it as success.
+		if strings.Contains(string(out), "already connected") {
+			logger.Debugf("NVMe-oFC nvmeConnect: path already connected NQN=%s target=%s host=%s",
+				subNqn, arrayTargetPort, hostPort)
+			return true
+		}
 		logger.Errorf("NVMe-oFC nvmeConnect: failed NQN=%s target=%s host=%s: %v output=%s",
 			subNqn, arrayTargetPort, hostPort, err, string(out))
 		return false

--- a/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc.go
@@ -448,26 +448,31 @@ func (r OsDeviceConnectivityNvmeOFc) GetMpathDevice(volumeId string) (string, er
 		logger.Warningf("NVMe-oFC GetMpathDevice: could not determine multipath mode: %v; using dm discovery", err)
 	}
 	if native {
-		return DiscoverNativeNamespaceDevice(r.Executer, volumeId)
+		// Stage runs right after the namespace rescan, so wait for udev to settle.
+		return DiscoverNativeNamespaceDevice(r.Executer, volumeId, WaitForMpathRetries)
 	}
 	return r.HelperScsiGeneric.GetMpathDevice(volumeId)
 }
 
 // DiscoverNativeNamespaceDevice finds the ANA namespace-head device for the volume by
-// its NGUID, retrying briefly while udev settles after the ns-rescan done in
-// RescanDevices (mirrors the dm path's "wait for dm to exist"). Returns the same
-// MultipathDeviceNotFoundForVolumeError as the dm path when nothing is found, so callers
-// (e.g. idempotent NodeUnstage) behave identically across modes. Exported so node-level
-// callers without a connectivity dispatch (NodeGetVolumeStats block path) can reuse it.
-func DiscoverNativeNamespaceDevice(exec executer.ExecuterInterface, volumeId string) (string, error) {
+// its NGUID. maxRetries bounds the wait while udev settles (stage passes the full retry
+// budget right after an ns-rescan; post-stage callers, whose device already exists, pass
+// 1). Returns the same MultipathDeviceNotFoundForVolumeError as the dm path when nothing
+// is found, so callers (e.g. idempotent NodeUnstage) behave identically across modes.
+// Exported so node-level callers without a connectivity dispatch can reuse it.
+func DiscoverNativeNamespaceDevice(exec executer.ExecuterInterface, volumeId string, maxRetries int) (string, error) {
 	nguid := convertScsiIdToNguid(strings.ToLower(volumeId))
 	logger.Infof("DiscoverNativeNamespaceDevice: resolving native NVMe head for volume %s (nguid=%s)", volumeId, nguid)
-	for i := 0; i < WaitForMpathRetries; i++ {
+	for i := 0; i < maxRetries; i++ {
 		if device := resolveNativeNamespaceOnce(exec, nguid); device != "" {
 			logger.Infof("DiscoverNativeNamespaceDevice: resolved volume %s to %s", volumeId, device)
 			return device, nil
 		}
-		time.Sleep(time.Second * time.Duration(WaitForMpathWaitIntervalSec))
+		// Sleep only between attempts, not after the last — a single-shot lookup
+		// (maxRetries=1, post-stage) returns immediately without a settle wait.
+		if i < maxRetries-1 {
+			time.Sleep(time.Second * time.Duration(WaitForMpathWaitIntervalSec))
+		}
 	}
 	logger.Errorf("DiscoverNativeNamespaceDevice: no native NVMe namespace for volume %s (nguid=%s)", volumeId, nguid)
 	return "", &MultipathDeviceNotFoundForVolumeError{volumeId}

--- a/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc.go
@@ -18,7 +18,9 @@ package device_connectivity
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/ibm/ibm-block-csi-driver/node/logger"
 	"github.com/ibm/ibm-block-csi-driver/node/pkg/driver/executer"
@@ -31,6 +33,12 @@ const (
 	FCPortPath                          = "/sys/class/fc_host/host*/port_name"
 	nvmeTargetPathCount                 = 3
 	nvmeMinPathsForNonNativeDmMultipath = 2
+	// nvmeByIdEuiPrefix is the stable udev by-id symlink prefix for an NVMe namespace
+	// keyed by its NGUID. Storage Virtualize exposes only an NGUID descriptor (no
+	// EUI-64), which udev labels with the "eui." prefix; the 32-hex value that follows
+	// is exactly what convertScsiIdToNguid derives from the SCSI volume UID.
+	nvmeByIdEuiPrefix    = "/dev/disk/by-id/nvme-eui."
+	sysBlockNvmeWwidGlob = "/sys/block/nvme*/wwid"
 )
 
 type OsDeviceConnectivityNvmeOFc struct {
@@ -423,8 +431,81 @@ func normalizeTraddr(traddr string) string {
 	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(traddr)), "0x", "")
 }
 
+// GetMpathDevice resolves the host block device for the volume. Under native NVMe
+// multipath (nvme_core.multipath=Y) the kernel presents the volume as a single
+// namespace-head /dev/nvmeXnY with no dm device, so the multipathd-based discovery
+// finds nothing; resolve the head by its NGUID instead. Under dm-multipath (=N)
+// delegate to the shared discovery unchanged. Scoped to NVMe/FC by dispatch, so SCSI
+// and iSCSI volumes on a native-NVMe host are unaffected.
 func (r OsDeviceConnectivityNvmeOFc) GetMpathDevice(volumeId string) (string, error) {
+	native, err := IsNvmeCoreMultipathEnabled(r.Executer)
+	if err != nil {
+		logger.Warningf("NVMe-oFC GetMpathDevice: could not determine multipath mode: %v; using dm discovery", err)
+	}
+	if native {
+		return r.discoverNativeNamespace(volumeId)
+	}
 	return r.HelperScsiGeneric.GetMpathDevice(volumeId)
+}
+
+// discoverNativeNamespace finds the ANA namespace-head device for the volume by its
+// NGUID, retrying briefly while udev settles after the ns-rescan done in RescanDevices
+// (mirrors the dm path's "wait for dm to exist"). Returns the same
+// MultipathDeviceNotFoundForVolumeError as the dm path when nothing is found, so
+// callers (e.g. idempotent NodeUnstage) behave identically across modes.
+func (r OsDeviceConnectivityNvmeOFc) discoverNativeNamespace(volumeId string) (string, error) {
+	nguid := convertScsiIdToNguid(strings.ToLower(volumeId))
+	logger.Infof("NVMe-oFC discoverNativeNamespace: resolving native NVMe head for volume %s (nguid=%s)", volumeId, nguid)
+	for i := 0; i < WaitForMpathRetries; i++ {
+		if device := r.resolveNativeNamespaceOnce(nguid); device != "" {
+			logger.Infof("NVMe-oFC discoverNativeNamespace: resolved volume %s to %s", volumeId, device)
+			return device, nil
+		}
+		time.Sleep(time.Second * time.Duration(WaitForMpathWaitIntervalSec))
+	}
+	logger.Errorf("NVMe-oFC discoverNativeNamespace: no native NVMe namespace for volume %s (nguid=%s)", volumeId, nguid)
+	return "", &MultipathDeviceNotFoundForVolumeError{volumeId}
+}
+
+// resolveNativeNamespaceOnce does one lookup: first the stable by-id symlink
+// /dev/disk/by-id/nvme-eui.<nguid>, then a sysfs scan of /sys/block/nvme*/wwid (in case
+// the udev symlink lags the rescan). Returns "" if the namespace is not yet present.
+func (r OsDeviceConnectivityNvmeOFc) resolveNativeNamespaceOnce(nguid string) string {
+	byIdPath := nvmeByIdEuiPrefix + nguid
+	if target, err := r.Executer.OsReadlink(byIdPath); err == nil && target != "" {
+		device := filepath.Join(DevPath, filepath.Base(target))
+		logger.Debugf("NVMe-oFC resolveNativeNamespaceOnce: %s -> %s", byIdPath, device)
+		return device
+	}
+
+	matches, err := r.Executer.FilepathGlob(sysBlockNvmeWwidGlob)
+	if err != nil {
+		logger.Warningf("NVMe-oFC resolveNativeNamespaceOnce: glob %s failed: %v", sysBlockNvmeWwidGlob, err)
+		return ""
+	}
+	for _, wwidPath := range matches {
+		data, err := r.Executer.IoutilReadFile(wwidPath)
+		if err != nil {
+			continue
+		}
+		if normalizeNguid(string(data)) == nguid {
+			// wwidPath = /sys/block/<dev>/wwid → the device name is the parent dir.
+			device := filepath.Join(DevPath, filepath.Base(filepath.Dir(wwidPath)))
+			logger.Debugf("NVMe-oFC resolveNativeNamespaceOnce: sysfs %s matched -> %s", wwidPath, device)
+			return device
+		}
+	}
+	return ""
+}
+
+// normalizeNguid strips the "eui."/"nguid." prefix, dashes, and case so a sysfs wwid
+// ("eui.5800…724") or a dashed sysfs nguid ("58000000-0000-…") compares equal to the
+// undashed 32-hex NGUID that convertScsiIdToNguid derives from the SCSI volume UID.
+func normalizeNguid(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = strings.TrimPrefix(s, "eui.")
+	s = strings.TrimPrefix(s, "nguid.")
+	return strings.ReplaceAll(s, "-", "")
 }
 
 func (r OsDeviceConnectivityNvmeOFc) FlushMultipathDevice(mpathDevice string) error {

--- a/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc_internal_test.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc_internal_test.go
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2019 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Internal (white-box) tests for unexported NVMe-oFC path-accounting helpers that need
+// no Executer mock — kept in package device_connectivity to avoid the mocks import cycle.
+package device_connectivity
+
+import "testing"
+
+func TestNormalizeTraddr(t *testing.T) {
+	cases := map[string]string{
+		"nn-0x500507681000e48b:pn-0x500507681019e48b": "nn-500507681000e48b:pn-500507681019e48b",
+		"nn-500507681000e48b:pn-500507681019e48b":     "nn-500507681000e48b:pn-500507681019e48b",
+		"NN-0X500507681000E48B":                       "nn-500507681000e48b",
+		"  nn-0x50:pn-0x60  ":                         "nn-50:pn-60",
+	}
+	for in, want := range cases {
+		if got := normalizeTraddr(in); got != want {
+			t.Fatalf("normalizeTraddr(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// Reproduces the canary mismatch: the kernel's list-subsys keys carry a "0x" prefix,
+// the publish-context array targets do not. Before normalization the count was always 0
+// despite live paths; it must now match.
+func TestCountLivePathsForSubsystem_0xPrefixMismatch(t *testing.T) {
+	livePaths := map[string]bool{
+		"nn-0x500507681000e48b:pn-0x500507681019e48b|nn-0x20007ca62a951ce7:pn-0x10007ca62a951ce7": true,
+		"nn-0x500507681000e48b:pn-0x50050768101be48b|nn-0x20007ca62a951ce7:pn-0x10007ca62a951ce7": true,
+		"nn-0x500507681000e49d:pn-0x500507681029e49d|nn-0x20007ca62a951ce8:pn-0x10007ca62a951ce8": true,
+		"nn-0xdeadbeefdeadbeef:pn-0xdeadbeefdeadbeef|nn-0x20007ca62a951ce8:pn-0x10007ca62a951ce8": true, // unrelated subsystem
+	}
+	arrayTargets := map[string][]string{
+		"nn-500507681000e48b:pn-500507681019e48b": nil,
+		"nn-500507681000e48b:pn-50050768101be48b": nil,
+		"nn-500507681000e49d:pn-500507681029e49d": nil,
+	}
+	if got := countLivePathsForSubsystem(livePaths, arrayTargets); got != 3 {
+		t.Fatalf("expected 3 matching live paths (unrelated subsystem excluded), got %d", got)
+	}
+
+	// No array targets in context → no matches.
+	if got := countLivePathsForSubsystem(livePaths, map[string][]string{}); got != 0 {
+		t.Fatalf("expected 0 with empty array targets, got %d", got)
+	}
+}

--- a/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc_native_test.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc_native_test.go
@@ -129,3 +129,51 @@ func TestNvmeOFcGetMpathDevice_NonNativeDelegates(t *testing.T) {
 		t.Fatalf("expected /dev/dm-3 (delegated), got %s", got)
 	}
 }
+
+func TestIsVolumePathMatchesVolumeId_Native(t *testing.T) {
+	const volumePath = "/var/lib/kubelet/pods/x/volumes/kubernetes.io~csi/pvc/mount"
+	variations := []string{nativeVolumeUID, nativeNguid}
+
+	t.Run("native head wwid matches the volume", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		exec := mocks.NewMockExecuterInterface(mockCtrl)
+		helper := mocks.NewMockOsDeviceConnectivityHelperInterface(mockCtrl)
+		o := NewOsDeviceConnectivityHelperScsiGenericForTest(exec, helper, nil)
+
+		helper.EXPECT().GetVolumeIdVariations(nativeVolumeUID).Return(variations)
+		helper.EXPECT().GetMpathDeviceName(volumePath).Return("nvme1n1", nil)
+		exec.EXPECT().IoutilReadFile(nativeCoreParam).Return([]byte("Y"), nil)
+		exec.EXPECT().IoutilReadFile("/sys/block/nvme1n1/wwid").Return([]byte("eui."+nativeNguid+"\n"), nil)
+
+		match, err := o.IsVolumePathMatchesVolumeId(nativeVolumeUID, volumePath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !match {
+			t.Fatalf("expected native wwid to match volume")
+		}
+	})
+
+	t.Run("native head wwid belongs to a different volume", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		exec := mocks.NewMockExecuterInterface(mockCtrl)
+		helper := mocks.NewMockOsDeviceConnectivityHelperInterface(mockCtrl)
+		o := NewOsDeviceConnectivityHelperScsiGenericForTest(exec, helper, nil)
+
+		helper.EXPECT().GetVolumeIdVariations(nativeVolumeUID).Return(variations)
+		helper.EXPECT().GetMpathDeviceName(volumePath).Return("nvme2n1", nil)
+		exec.EXPECT().IoutilReadFile(nativeCoreParam).Return([]byte("Y"), nil)
+		exec.EXPECT().IoutilReadFile("/sys/block/nvme2n1/wwid").
+			Return([]byte("eui.99990000000000390050760810818724"), nil)
+
+		match, err := o.IsVolumePathMatchesVolumeId(nativeVolumeUID, volumePath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if match {
+			t.Fatalf("expected mismatch for a different volume's wwid")
+		}
+	})
+}

--- a/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc_native_test.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc_native_test.go
@@ -17,6 +17,7 @@
 package device_connectivity_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -174,6 +175,82 @@ func TestIsVolumePathMatchesVolumeId_Native(t *testing.T) {
 		}
 		if match {
 			t.Fatalf("expected mismatch for a different volume's wwid")
+		}
+	})
+}
+
+func TestRescanNvmeNamespaceForResize(t *testing.T) {
+	const (
+		nsDevice    = "nvme1n1"
+		nsNqnPath   = "/sys/block/nvme1n1/device/subsysnqn"
+		ctrlGlob    = "/sys/class/nvme/nvme*/subsysnqn"
+		arraySubsys = "nqn.1986-03.com.ibm:nvme:2145.000002042061C916"
+	)
+	expectSubsysRead := func(exec *mocks.MockExecuterInterface, val string, err error) {
+		exec.EXPECT().IoutilReadFile(nsNqnPath).Return([]byte(val), err)
+	}
+
+	t.Run("rescans only the namespace's subsystem controllers", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		exec := mocks.NewMockExecuterInterface(mockCtrl)
+		expectSubsysRead(exec, arraySubsys+"\n", nil)
+		exec.EXPECT().FilepathGlob(ctrlGlob).Return([]string{
+			"/sys/class/nvme/nvme0/subsysnqn",
+			"/sys/class/nvme/nvme1/subsysnqn",
+			"/sys/class/nvme/nvme2/subsysnqn",
+		}, nil)
+		exec.EXPECT().IoutilReadFile("/sys/class/nvme/nvme0/subsysnqn").Return([]byte("nqn.local:boot"), nil)
+		exec.EXPECT().IoutilReadFile("/sys/class/nvme/nvme1/subsysnqn").Return([]byte(arraySubsys), nil)
+		exec.EXPECT().IoutilReadFile("/sys/class/nvme/nvme2/subsysnqn").Return([]byte(arraySubsys+"\n"), nil)
+		exec.EXPECT().ExecuteWithTimeout(gomock.Any(), "nvme", []string{"ns-rescan", "/dev/nvme1"}).Return([]byte(""), nil)
+		exec.EXPECT().ExecuteWithTimeout(gomock.Any(), "nvme", []string{"ns-rescan", "/dev/nvme2"}).Return([]byte(""), nil)
+
+		if err := device_connectivity.RescanNvmeNamespaceForResize(exec, nsDevice); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("subsysnqn unreadable is non-fatal (relies on kernel AEN)", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		exec := mocks.NewMockExecuterInterface(mockCtrl)
+		expectSubsysRead(exec, "", os.ErrNotExist)
+		// no glob / rescan expected
+		if err := device_connectivity.RescanNvmeNamespaceForResize(exec, nsDevice); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("no controller matches the subsystem is non-fatal", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		exec := mocks.NewMockExecuterInterface(mockCtrl)
+		expectSubsysRead(exec, arraySubsys, nil)
+		exec.EXPECT().FilepathGlob(ctrlGlob).Return([]string{"/sys/class/nvme/nvme0/subsysnqn"}, nil)
+		exec.EXPECT().IoutilReadFile("/sys/class/nvme/nvme0/subsysnqn").Return([]byte("nqn.local:boot"), nil)
+		// no rescan expected
+		if err := device_connectivity.RescanNvmeNamespaceForResize(exec, nsDevice); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("per-controller rescan failure is non-fatal and still tries the rest", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		exec := mocks.NewMockExecuterInterface(mockCtrl)
+		expectSubsysRead(exec, arraySubsys, nil)
+		exec.EXPECT().FilepathGlob(ctrlGlob).Return([]string{
+			"/sys/class/nvme/nvme1/subsysnqn",
+			"/sys/class/nvme/nvme2/subsysnqn",
+		}, nil)
+		exec.EXPECT().IoutilReadFile("/sys/class/nvme/nvme1/subsysnqn").Return([]byte(arraySubsys), nil)
+		exec.EXPECT().IoutilReadFile("/sys/class/nvme/nvme2/subsysnqn").Return([]byte(arraySubsys), nil)
+		exec.EXPECT().ExecuteWithTimeout(gomock.Any(), "nvme", []string{"ns-rescan", "/dev/nvme1"}).Return([]byte(""), fmt.Errorf("exit status 1"))
+		exec.EXPECT().ExecuteWithTimeout(gomock.Any(), "nvme", []string{"ns-rescan", "/dev/nvme2"}).Return([]byte(""), nil)
+
+		if err := device_connectivity.RescanNvmeNamespaceForResize(exec, nsDevice); err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 }

--- a/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc_native_test.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc_native_test.go
@@ -1,0 +1,131 @@
+/**
+ * Copyright 2019 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package device_connectivity_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/ibm/ibm-block-csi-driver/node/mocks"
+	"github.com/ibm/ibm-block-csi-driver/node/pkg/driver/device_connectivity"
+)
+
+// Native NVMe discovery test fixtures. The volume UID → NGUID derivation is
+// convertScsiIdToNguid; for this SCSI UID the kernel wwid / by-id name is the
+// undashed 32-hex NGUID below (confirmed against a live host's /sys/block/*/wwid).
+const (
+	nativeVolumeUID   = "60050768108187245800000000000039"
+	nativeNguid       = "58000000000000390050760810818724"
+	nativeCoreParam   = "/sys/module/nvme_core/parameters/multipath"
+	nativeByIdPath    = "/dev/disk/by-id/nvme-eui." + nativeNguid
+	nativeWwidGlob    = "/sys/block/nvme*/wwid"
+	nativeHeadDevice  = "/dev/nvme1n1"
+	otherWwidFilePath = "/sys/block/nvme0n1/wwid"
+	headWwidFilePath  = "/sys/block/nvme1n1/wwid"
+)
+
+func newNativeNvmeOFc(
+	exec *mocks.MockExecuterInterface,
+	helper *mocks.MockOsDeviceConnectivityHelperScsiGenericInterface,
+) device_connectivity.OsDeviceConnectivityInterface {
+	return &device_connectivity.OsDeviceConnectivityNvmeOFc{Executer: exec, HelperScsiGeneric: helper}
+}
+
+func expectNativeMode(exec *mocks.MockExecuterInterface, on bool) {
+	val := "N"
+	if on {
+		val = "Y"
+	}
+	exec.EXPECT().IoutilReadFile(nativeCoreParam).Return([]byte(val), nil).AnyTimes()
+}
+
+func TestNvmeOFcGetMpathDevice_Native(t *testing.T) {
+	t.Run("by-id symlink resolves the namespace head", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		exec := mocks.NewMockExecuterInterface(mockCtrl)
+		expectNativeMode(exec, true)
+		exec.EXPECT().OsReadlink(nativeByIdPath).Return("../../nvme1n1", nil)
+
+		got, err := newNativeNvmeOFc(exec, nil).GetMpathDevice(nativeVolumeUID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nativeHeadDevice {
+			t.Fatalf("expected %s, got %s", nativeHeadDevice, got)
+		}
+	})
+
+	t.Run("sysfs wwid fallback when by-id symlink absent", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		exec := mocks.NewMockExecuterInterface(mockCtrl)
+		expectNativeMode(exec, true)
+		exec.EXPECT().OsReadlink(nativeByIdPath).Return("", os.ErrNotExist).AnyTimes()
+		exec.EXPECT().FilepathGlob(nativeWwidGlob).
+			Return([]string{otherWwidFilePath, headWwidFilePath}, nil).AnyTimes()
+		exec.EXPECT().IoutilReadFile(otherWwidFilePath).
+			Return([]byte("eui.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), nil).AnyTimes()
+		// Dashed sysfs form must still match the undashed derived NGUID (normalization).
+		exec.EXPECT().IoutilReadFile(headWwidFilePath).
+			Return([]byte("eui.58000000-0000-0039-0050-760810818724\n"), nil).AnyTimes()
+
+		got, err := newNativeNvmeOFc(exec, nil).GetMpathDevice(nativeVolumeUID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nativeHeadDevice {
+			t.Fatalf("expected %s, got %s", nativeHeadDevice, got)
+		}
+	})
+
+	t.Run("namespace not present -> MultipathDeviceNotFoundForVolumeError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		exec := mocks.NewMockExecuterInterface(mockCtrl)
+		expectNativeMode(exec, true)
+		exec.EXPECT().OsReadlink(nativeByIdPath).Return("", os.ErrNotExist).AnyTimes()
+		exec.EXPECT().FilepathGlob(nativeWwidGlob).Return([]string{}, nil).AnyTimes()
+
+		_, err := newNativeNvmeOFc(exec, nil).GetMpathDevice(nativeVolumeUID)
+		if err == nil {
+			t.Fatalf("expected not-found error, got nil")
+		}
+		if _, ok := err.(*device_connectivity.MultipathDeviceNotFoundForVolumeError); !ok {
+			t.Fatalf("expected MultipathDeviceNotFoundForVolumeError, got %T: %v", err, err)
+		}
+	})
+}
+
+func TestNvmeOFcGetMpathDevice_NonNativeDelegates(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	exec := mocks.NewMockExecuterInterface(mockCtrl)
+	helper := mocks.NewMockOsDeviceConnectivityHelperScsiGenericInterface(mockCtrl)
+	expectNativeMode(exec, false)
+	// dm-multipath mode: GetMpathDevice must delegate to the shared helper unchanged.
+	helper.EXPECT().GetMpathDevice(nativeVolumeUID).Return("/dev/dm-3", nil)
+
+	got, err := newNativeNvmeOFc(exec, helper).GetMpathDevice(nativeVolumeUID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "/dev/dm-3" {
+		t.Fatalf("expected /dev/dm-3 (delegated), got %s", got)
+	}
+}

--- a/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc_test.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc_test.go
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2019 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package device_connectivity_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/ibm/ibm-block-csi-driver/node/mocks"
+	"github.com/ibm/ibm-block-csi-driver/node/pkg/driver/device_connectivity"
+)
+
+// listSubsysTwoArrayCtrlsPlusBoot: two FC controllers on the array subsystem
+// (nvme0, nvme1) plus an unrelated local boot NVMe (nvme2). list-subsys emits
+// traddrs with the "0x" hex prefix; the publish-context target ports do not.
+const listSubsysTwoArrayCtrlsPlusBoot = `nvme-subsys0 - NQN=nqn.1986-03.com.ibm:nvme:2145.000002042061C916
+\
+ +- nvme0 fc traddr=nn-0x500507680b21c8f4:pn-0x500507680b22c8f4 host_traddr=nn-0x20000024ff8b1a2c:pn-0x21000024ff8b1a2c live
+ +- nvme1 fc traddr=nn-0x500507680b21c8f5:pn-0x500507680b22c8f5 host_traddr=nn-0x20000024ff8b1a2d:pn-0x21000024ff8b1a2d live
+nvme-subsys1 - NQN=nqn.2019-08.local:boot
+\
+ +- nvme2 pcie traddr=0000:04:00.0 live
+`
+
+func newNvmeOFcForTest(exec *mocks.MockExecuterInterface) device_connectivity.OsDeviceConnectivityInterface {
+	return &device_connectivity.OsDeviceConnectivityNvmeOFc{
+		Executer:          exec,
+		HelperScsiGeneric: nil, // RescanDevices does not use the helper
+	}
+}
+
+// arrayTargets are the two array target ports (publish-context format, no 0x)
+// matching nvme0 and nvme1 above.
+var arrayTargets = []string{
+	"nn-500507680b21c8f4:pn-500507680b22c8f4",
+	"nn-500507680b21c8f5:pn-500507680b22c8f5",
+}
+
+func expectListSubsys(exec *mocks.MockExecuterInterface, output string, err error) {
+	exec.EXPECT().
+		ExecuteWithTimeout(gomock.Any(), "nvme", []string{"list-subsys"}).
+		Return([]byte(output), err)
+}
+
+func expectNsRescan(exec *mocks.MockExecuterInterface, controllerDev string, err error) {
+	exec.EXPECT().
+		ExecuteWithTimeout(gomock.Any(), "nvme", []string{"ns-rescan", controllerDev}).
+		Return([]byte(""), err).
+		Times(1)
+}
+
+func TestNvmeOFcRescanDevices(t *testing.T) {
+	testCases := []struct {
+		name       string
+		arrayPorts []string
+		// setup registers the exact Executer calls this case expects; gomock
+		// fails the test if the code issues a call that was not registered.
+		setup   func(exec *mocks.MockExecuterInterface)
+		wantErr bool
+	}{
+		{
+			name:       "rescans only the array's controllers, not the boot NVMe",
+			arrayPorts: arrayTargets,
+			setup: func(exec *mocks.MockExecuterInterface) {
+				expectListSubsys(exec, listSubsysTwoArrayCtrlsPlusBoot, nil)
+				expectNsRescan(exec, "/dev/nvme0", nil)
+				expectNsRescan(exec, "/dev/nvme1", nil)
+			},
+			wantErr: false,
+		},
+		{
+			name:       "matches a single target port, rescans its controller only",
+			arrayPorts: []string{arrayTargets[0]},
+			setup: func(exec *mocks.MockExecuterInterface) {
+				expectListSubsys(exec, listSubsysTwoArrayCtrlsPlusBoot, nil)
+				expectNsRescan(exec, "/dev/nvme0", nil)
+			},
+			wantErr: false,
+		},
+		{
+			name:       "no target ports: skips rescan entirely, non-fatal",
+			arrayPorts: []string{},
+			setup:      func(exec *mocks.MockExecuterInterface) {}, // no calls expected
+			wantErr:    false,
+		},
+		{
+			name:       "no controller matches the array: skips rescan, non-fatal",
+			arrayPorts: []string{"nn-aaaaaaaaaaaaaaaa:pn-bbbbbbbbbbbbbbbb"},
+			setup: func(exec *mocks.MockExecuterInterface) {
+				expectListSubsys(exec, listSubsysTwoArrayCtrlsPlusBoot, nil)
+				// no ns-rescan expected
+			},
+			wantErr: false,
+		},
+		{
+			name:       "list-subsys fails: non-fatal, no rescan, no error",
+			arrayPorts: arrayTargets,
+			setup: func(exec *mocks.MockExecuterInterface) {
+				expectListSubsys(exec, "", fmt.Errorf("nvme list-subsys: command not found"))
+			},
+			wantErr: false,
+		},
+		{
+			name:       "per-controller ns-rescan failure is non-fatal and still tries the rest",
+			arrayPorts: arrayTargets,
+			setup: func(exec *mocks.MockExecuterInterface) {
+				expectListSubsys(exec, listSubsysTwoArrayCtrlsPlusBoot, nil)
+				expectNsRescan(exec, "/dev/nvme0", fmt.Errorf("exit status 1"))
+				expectNsRescan(exec, "/dev/nvme1", nil) // still attempted despite nvme0 failing
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			exec := mocks.NewMockExecuterInterface(mockCtrl)
+			tc.setup(exec)
+
+			r := newNvmeOFcForTest(exec)
+			err := r.RescanDevices(0, tc.arrayPorts)
+
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+		})
+	}
+}

--- a/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc_test.go
+++ b/node/pkg/driver/device_connectivity/device_connectivity_nvmeofc_test.go
@@ -18,6 +18,7 @@ package device_connectivity_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -143,6 +144,45 @@ func TestNvmeOFcRescanDevices(t *testing.T) {
 			}
 			if !tc.wantErr && err != nil {
 				t.Fatalf("expected nil error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestIsNvmeCoreMultipathEnabled(t *testing.T) {
+	const paramPath = "/sys/module/nvme_core/parameters/multipath"
+	testCases := []struct {
+		name       string
+		readReturn []byte
+		readErr    error
+		want       bool
+		wantErr    bool
+	}{
+		{name: "Y -> native", readReturn: []byte("Y"), want: true},
+		{name: "Y with newline -> native (trimmed)", readReturn: []byte("Y\n"), want: true},
+		{name: "N -> dm-multipath", readReturn: []byte("N"), want: false},
+		{name: "empty -> not native", readReturn: []byte(""), want: false},
+		{name: "param file absent (nvme_core not loaded) -> not native, no error", readErr: os.ErrNotExist, want: false},
+		{name: "unexpected read error -> propagated", readErr: fmt.Errorf("permission denied"), want: false, wantErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			exec := mocks.NewMockExecuterInterface(mockCtrl)
+			exec.EXPECT().IoutilReadFile(paramPath).Return(tc.readReturn, tc.readErr)
+
+			got, err := device_connectivity.IsNvmeCoreMultipathEnabled(exec)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("expected %v, got %v", tc.want, got)
 			}
 		})
 	}

--- a/node/pkg/driver/node.go
+++ b/node/pkg/driver/node.go
@@ -173,15 +173,26 @@ func (d *NodeService) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
 	baseDevice := path.Base(mpathDevice)
-	sysDevices, err := d.NodeUtils.GetSysDevicesFromMpath(baseDevice)
+
+	nvmeType, err := d.NodeUtils.DevicesAreNvme(baseDevice)
 	if err != nil {
-		logger.Errorf("Error while trying to get sys devices : {%v}", err.Error())
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Errorf(codes.Internal, "Failed to determine device type for %s: %v", baseDevice, err)
 	}
-	err = osDeviceConnectivity.ValidateLun(lun, sysDevices)
-	if err != nil {
-		logger.Errorf("Error while trying to validate lun : {%v}", err.Error())
-		return nil, status.Error(codes.Internal, err.Error())
+	// Native NVMe multipath presents a namespace head with no dm slaves to enumerate,
+	// and the kernel manages ANA paths; skip physical-path discovery + lun validation
+	// (ValidateLun is a no-op for NVMe anyway). dm-multipath (SCSI/iSCSI/non-native
+	// NVMe) still validates the physical paths behind the dm device.
+	if nvmeType != NVMeNative {
+		sysDevices, err := d.NodeUtils.GetSysDevicesFromMpath(baseDevice)
+		if err != nil {
+			logger.Errorf("Error while trying to get sys devices : {%v}", err.Error())
+			return nil, status.Error(codes.Internal, err.Error())
+		}
+		err = osDeviceConnectivity.ValidateLun(lun, sysDevices)
+		if err != nil {
+			logger.Errorf("Error while trying to validate lun : {%v}", err.Error())
+			return nil, status.Error(codes.Internal, err.Error())
+		}
 	}
 
 	existingFormat, err := d.Mounter.GetDiskFormat(mpathDevice)

--- a/node/pkg/driver/node.go
+++ b/node/pkg/driver/node.go
@@ -378,7 +378,7 @@ func (d *NodeService) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 	}
 
 	volumeUuid := d.NodeUtils.GetVolumeUuid(volumeID)
-	mpathDevice, err := d.OsDeviceConnectivityHelper.GetMpathDevice(volumeUuid)
+	mpathDevice, err := d.NodeUtils.DiscoverMpathDevice(volumeUuid)
 	if err != nil {
 		switch err.(type) {
 		case *device_connectivity.MultipathDeviceNotFoundForVolumeError:
@@ -518,7 +518,7 @@ func (d *NodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		err = d.publishFileSystemVolume(stagingPath, targetPath, fsType)
 	} else {
 		volumeUuid := d.NodeUtils.GetVolumeUuid(volumeID)
-		mpathDevice, err := d.OsDeviceConnectivityHelper.GetMpathDevice(volumeUuid)
+		mpathDevice, err := d.NodeUtils.DiscoverMpathDevice(volumeUuid)
 		if err != nil {
 			logger.Errorf("Error while discovering the device : {%v}", err.Error())
 			return nil, status.Error(codes.Internal, err.Error())
@@ -766,7 +766,7 @@ func (d *NodeService) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandV
 	defer d.VolumeIdLocksMap.RemoveVolumeLock(volumeID, "NodeExpandVolume")
 
 	volumeUuid := d.NodeUtils.GetVolumeUuid(volumeID)
-	device, err := d.OsDeviceConnectivityHelper.GetMpathDevice(volumeUuid)
+	device, err := d.NodeUtils.DiscoverMpathDevice(volumeUuid)
 	if err != nil {
 		logger.Errorf("Error while discovering the device : {%v}", err.Error())
 		return nil, status.Error(codes.Internal, err.Error())

--- a/node/pkg/driver/node.go
+++ b/node/pkg/driver/node.go
@@ -782,8 +782,13 @@ func (d *NodeService) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandV
 
 	switch nvmeType {
 	case NVMeNative:
-		// Native NVMe → skip multipath/rescan
-		logger.Infof("Device %s is native NVMe: skipping multipath expand/rescan", baseDevice)
+		// Native NVMe → no dm device to resize; rescan the namespace so the kernel picks
+		// up the new size before growing the filesystem (otherwise it under-expands).
+		logger.Infof("Device %s is native NVMe: rescanning namespace to refresh size", baseDevice)
+		err = d.NodeUtils.RescanNvmeNamespace(baseDevice)
+		if err != nil {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
 
 	case NVMeNonNative:
 		// Non-native NVMe → skip rescan, only expand multipath

--- a/node/pkg/driver/node_test.go
+++ b/node/pkg/driver/node_test.go
@@ -309,6 +309,7 @@ func TestNodeStageVolume(t *testing.T) {
 				mockOsDeviceCon.EXPECT().RescanDevices(lun, arrayInitiators).Return(nil)
 				mockNodeUtils.EXPECT().GetVolumeUuid(volId).Return(volId)
 				mockOsDeviceCon.EXPECT().GetMpathDevice(volId).Return(mpathDevice, nil)
+				mockNodeUtils.EXPECT().DevicesAreNvme(dmSysFsName).Return(driver.NotNVMe, nil)
 				mockNodeUtils.EXPECT().GetSysDevicesFromMpath(dmSysFsName).Return(sysDevices, nil)
 				mockOsDeviceCon.EXPECT().ValidateLun(lun, sysDevices).Return(nil)
 				mockMounter.EXPECT().GetDiskFormat(mpathDevice).Return("", dummyError)
@@ -337,8 +338,44 @@ func TestNodeStageVolume(t *testing.T) {
 				mockOsDeviceCon.EXPECT().RescanDevices(lun, arrayInitiators).Return(nil)
 				mockNodeUtils.EXPECT().GetVolumeUuid(volId).Return(volId)
 				mockOsDeviceCon.EXPECT().GetMpathDevice(volId).Return(mpathDevice, nil)
+				mockNodeUtils.EXPECT().DevicesAreNvme(dmSysFsName).Return(driver.NotNVMe, nil)
 				mockNodeUtils.EXPECT().GetSysDevicesFromMpath(dmSysFsName).Return(sysDevices, nil)
 				mockOsDeviceCon.EXPECT().ValidateLun(lun, sysDevices).Return(nil)
+				mockMounter.EXPECT().GetDiskFormat(mpathDevice).Return("", nil)
+				mockNodeUtils.EXPECT().GetPodPath(stagingPath).Return(stagingPathWithHostPrefix)
+				mockNodeUtils.EXPECT().IsNotMountPoint(stagingPathWithHostPrefix).Return(true, nil)
+				mockNodeUtils.EXPECT().FormatDevice(mpathDevice, fsType)
+				mockMounter.EXPECT().FormatAndMount(mpathDevice, stagingPath, fsType, mountOptions)
+
+				_, err := node.NodeStageVolume(context.TODO(), stagingRequest)
+				if err != nil {
+					t.Fatalf("Expect no error but got: %v", err)
+				}
+			},
+		},
+		{
+			name: "success native NVMe skips sys-device discovery and lun validation",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				defer mockCtl.Finish()
+				mockNodeUtils := mocks.NewMockNodeUtilsInterface(mockCtl)
+				mockOsDeviceCon := mocks.NewMockOsDeviceConnectivityInterface(mockCtl)
+				mockOsDeviceConHelper := mocks.NewMockOsDeviceConnectivityHelperScsiGenericInterface(mockCtl)
+				mockMounter := mocks.NewMockNodeMounter(mockCtl)
+				node := newTestNodeServiceStaging(mockNodeUtils, mockOsDeviceCon, mockOsDeviceConHelper, mockMounter)
+
+				mockNodeUtils.EXPECT().GetPodPath(stagingPath).Return(stagingPathWithHostPrefix)
+				mockNodeUtils.EXPECT().IsPathExists(stagingPathWithHostPrefix).Return(true)
+				mockNodeUtils.EXPECT().GetInfoFromPublishContext(stagingRequest.PublishContext).Return(conType, lun, ipsByArrayInitiator, nil).AnyTimes()
+				mockNodeUtils.EXPECT().GetArrayInitiators(ipsByArrayInitiator).Return(arrayInitiators)
+				mockOsDeviceCon.EXPECT().EnsureLogin(ipsByArrayInitiator)
+				mockOsDeviceConHelper.EXPECT().RemoveGhostDevice(lun).Return(nil).Times(2)
+				mockOsDeviceCon.EXPECT().RescanDevices(lun, arrayInitiators).Return(nil)
+				mockNodeUtils.EXPECT().GetVolumeUuid(volId).Return(volId)
+				mockOsDeviceCon.EXPECT().GetMpathDevice(volId).Return(mpathDevice, nil)
+				// Native NVMe: no GetSysDevicesFromMpath / ValidateLun expectations — gomock
+				// fails if the code calls them, proving the native branch skips both.
+				mockNodeUtils.EXPECT().DevicesAreNvme(dmSysFsName).Return(driver.NVMeNative, nil)
 				mockMounter.EXPECT().GetDiskFormat(mpathDevice).Return("", nil)
 				mockNodeUtils.EXPECT().GetPodPath(stagingPath).Return(stagingPathWithHostPrefix)
 				mockNodeUtils.EXPECT().IsNotMountPoint(stagingPathWithHostPrefix).Return(true, nil)
@@ -371,6 +408,7 @@ func TestNodeStageVolume(t *testing.T) {
 				mockOsDeviceCon.EXPECT().RescanDevices(lun, arrayInitiators).Return(nil)
 				mockNodeUtils.EXPECT().GetVolumeUuid(volId).Return(volId)
 				mockOsDeviceCon.EXPECT().GetMpathDevice(volId).Return(mpathDevice, nil)
+				mockNodeUtils.EXPECT().DevicesAreNvme(dmSysFsName).Return(driver.NotNVMe, nil)
 				mockNodeUtils.EXPECT().GetSysDevicesFromMpath(dmSysFsName).Return(sysDevices, nil)
 				mockOsDeviceCon.EXPECT().ValidateLun(lun, sysDevices).Return(nil)
 				mockMounter.EXPECT().GetDiskFormat(mpathDevice).Return(fsType, nil)
@@ -404,6 +442,7 @@ func TestNodeStageVolume(t *testing.T) {
 				mockOsDeviceCon.EXPECT().RescanDevices(lun, arrayInitiators).Return(nil)
 				mockNodeUtils.EXPECT().GetVolumeUuid(volId).Return(volId)
 				mockOsDeviceCon.EXPECT().GetMpathDevice(volId).Return(mpathDevice, nil)
+				mockNodeUtils.EXPECT().DevicesAreNvme(dmSysFsName).Return(driver.NotNVMe, nil)
 				mockNodeUtils.EXPECT().GetSysDevicesFromMpath(dmSysFsName).Return(sysDevices, nil)
 				mockOsDeviceCon.EXPECT().ValidateLun(lun, sysDevices).Return(nil)
 				mockMounter.EXPECT().GetDiskFormat(mpathDevice).Return(fsType, nil)
@@ -434,6 +473,7 @@ func TestNodeStageVolume(t *testing.T) {
 				mockNodeUtils.EXPECT().GetArrayInitiators(ipsByArrayInitiator).Return(arrayInitiators)
 				mockOsDeviceCon.EXPECT().EnsureLogin(ipsByArrayInitiator)
 				mockOsDeviceConHelper.EXPECT().RemoveGhostDevice(lun).Return(nil).Times(2)
+				mockNodeUtils.EXPECT().DevicesAreNvme(dmSysFsName).Return(driver.NotNVMe, nil)
 				mockNodeUtils.EXPECT().GetSysDevicesFromMpath(dmSysFsName).Return(sysDevices, nil)
 				mockOsDeviceCon.EXPECT().ValidateLun(lun, sysDevices).Return(nil)
 				mockOsDeviceCon.EXPECT().RescanDevices(lun, arrayInitiators).Return(nil)

--- a/node/pkg/driver/node_test.go
+++ b/node/pkg/driver/node_test.go
@@ -1338,6 +1338,31 @@ func TestNodeExpandVolume(t *testing.T) {
 			},
 		},
 		{
+			name: "success expand volume, native nvme rescans namespace",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				defer mockCtl.Finish()
+				mockNodeUtils := mocks.NewMockNodeUtilsInterface(mockCtl)
+				mockOsDeviceConHelper := mocks.NewMockOsDeviceConnectivityHelperScsiGenericInterface(mockCtl)
+				mockMounter := mocks.NewMockNodeMounter(mockCtl)
+				node := newTestNodeServiceExpand(mockNodeUtils, mockOsDeviceConHelper, mockMounter)
+
+				mockNodeUtils.EXPECT().GetVolumeUuid(volId).Return(volId)
+				mockOsDeviceConHelper.EXPECT().GetMpathDevice(volId).Return(mpathDevice, nil)
+				mockNodeUtils.EXPECT().DevicesAreNvme(dmSysFsName).Return(driver.NVMeNative, nil)
+				// Native NVMe rescans the namespace instead of the dm-multipath device.
+				// No ExpandMpathDevice / GetSysDevicesFromMpath / RescanPhysicalDevices expected.
+				mockNodeUtils.EXPECT().RescanNvmeNamespace(dmSysFsName).Return(nil)
+				mockMounter.EXPECT().GetDiskFormat(mpathDevice).Return(fsType, nil)
+				mockNodeUtils.EXPECT().ExpandFilesystem(mpathDevice, stagingTargetPath, fsType).Return(nil)
+
+				_, err := node.NodeExpandVolume(context.TODO(), expandRequest)
+				if err != nil {
+					t.Fatalf("Expect no error but got: %v", err)
+				}
+			},
+		},
+		{
 			name: "success expand volume",
 			testFunc: func(t *testing.T) {
 				mockCtl := gomock.NewController(t)

--- a/node/pkg/driver/node_test.go
+++ b/node/pkg/driver/node_test.go
@@ -544,7 +544,7 @@ func TestNodeUnstageVolume(t *testing.T) {
 				mockNodeUtils.EXPECT().GetPodPath(stagingPath).Return(stagingPathWithHostPrefix)
 				mockNodeUtils.EXPECT().IsNotMountPoint(stagingPathWithHostPrefix).Return(true, nil)
 				mockNodeUtils.EXPECT().GetVolumeUuid(volId).Return(volId)
-				mockOsDeviceConHelper.EXPECT().GetMpathDevice(volId).Return("", dummyError)
+				mockNodeUtils.EXPECT().DiscoverMpathDevice(volId).Return("", dummyError)
 
 				_, err := node.NodeUnstageVolume(context.TODO(), unstageRequest)
 				assertError(t, err, codes.Internal)
@@ -563,7 +563,7 @@ func TestNodeUnstageVolume(t *testing.T) {
 				mockNodeUtils.EXPECT().GetPodPath(stagingPath).Return(stagingPathWithHostPrefix)
 				mockNodeUtils.EXPECT().IsNotMountPoint(stagingPathWithHostPrefix).Return(true, nil)
 				mockNodeUtils.EXPECT().GetVolumeUuid(volId).Return(volId)
-				mockOsDeviceConHelper.EXPECT().GetMpathDevice(volId).Return(dmSysFsName, nil)
+				mockNodeUtils.EXPECT().DiscoverMpathDevice(volId).Return(dmSysFsName, nil)
 				mockNodeUtils.EXPECT().DevicesAreNvme(dmSysFsName).Return(driver.NotNVMe, nil)
 				mockNodeUtils.EXPECT().GetSysDevicesFromMpath(dmSysFsName).Return(sysDevices, nil)
 				mockOsDeviceConHelper.EXPECT().FlushMultipathDevice(dmSysFsName).Return(dummyError)
@@ -585,7 +585,7 @@ func TestNodeUnstageVolume(t *testing.T) {
 				mockNodeUtils.EXPECT().GetPodPath(stagingPath).Return(stagingPathWithHostPrefix)
 				mockNodeUtils.EXPECT().IsNotMountPoint(stagingPathWithHostPrefix).Return(true, nil)
 				mockNodeUtils.EXPECT().GetVolumeUuid(volId).Return(volId)
-				mockOsDeviceConHelper.EXPECT().GetMpathDevice(volId).Return("", dmNotFoundError)
+				mockNodeUtils.EXPECT().DiscoverMpathDevice(volId).Return("", dmNotFoundError)
 
 				_, err := node.NodeUnstageVolume(context.TODO(), unstageRequest)
 				if err != nil {
@@ -607,7 +607,7 @@ func TestNodeUnstageVolume(t *testing.T) {
 				mockNodeUtils.EXPECT().IsNotMountPoint(stagingPathWithHostPrefix).Return(false, nil)
 				mockMounter.EXPECT().Unmount(stagingPath).Return(nil)
 				mockNodeUtils.EXPECT().GetVolumeUuid(volId).Return(volId)
-				mockOsDeviceConHelper.EXPECT().GetMpathDevice(volId).Return(dmSysFsName, nil)
+				mockNodeUtils.EXPECT().DiscoverMpathDevice(volId).Return(dmSysFsName, nil)
 				mockNodeUtils.EXPECT().DevicesAreNvme(dmSysFsName).Return(driver.NotNVMe, nil)
 				mockNodeUtils.EXPECT().GetSysDevicesFromMpath(dmSysFsName).Return(sysDevices, nil)
 				mockOsDeviceConHelper.EXPECT().FlushMultipathDevice(dmSysFsName).Return(nil)
@@ -839,7 +839,7 @@ func TestNodePublishVolume(t *testing.T) {
 				mockNodeUtils.EXPECT().IsPathExists(targetPathWithHostPrefix).Return(false)
 				mockNodeUtils.EXPECT().MakeFile(gomock.Eq(targetPathWithHostPrefix)).Return(nil)
 				mockNodeUtils.EXPECT().GetVolumeUuid(volumeId).Return(volumeId)
-				mockOsDeviceConHelper.EXPECT().GetMpathDevice(volumeId).Return(mpathDevice, nil)
+				mockNodeUtils.EXPECT().DiscoverMpathDevice(volumeId).Return(mpathDevice, nil)
 				mockMounter.EXPECT().Mount(mpathDevice, targetPath, "", []string{"bind"})
 
 				req := &csi.NodePublishVolumeRequest{
@@ -870,7 +870,7 @@ func TestNodePublishVolume(t *testing.T) {
 				mockNodeUtils.EXPECT().IsPathExists(targetPathWithHostPrefix).Return(true)
 				mockNodeUtils.EXPECT().IsNotMountPoint(targetPathWithHostPrefix).Return(true, nil)
 				mockNodeUtils.EXPECT().GetVolumeUuid(volumeId).Return(volumeId)
-				mockOsDeviceConHelper.EXPECT().GetMpathDevice(volumeId).Return(mpathDevice, nil)
+				mockNodeUtils.EXPECT().DiscoverMpathDevice(volumeId).Return(mpathDevice, nil)
 				mockMounter.EXPECT().Mount(mpathDevice, targetPath, "", []string{"bind"})
 
 				req := &csi.NodePublishVolumeRequest{
@@ -1203,7 +1203,7 @@ func TestNodeExpandVolume(t *testing.T) {
 				node := newTestNodeServiceExpand(mockNodeUtils, mockOsDeviceConHelper, mockMounter)
 
 				mockNodeUtils.EXPECT().GetVolumeUuid(volId).Return(volId)
-				mockOsDeviceConHelper.EXPECT().GetMpathDevice(volId).Return("", dummyError)
+				mockNodeUtils.EXPECT().DiscoverMpathDevice(volId).Return("", dummyError)
 
 				_, err := node.NodeExpandVolume(context.TODO(), expandRequest)
 				assertError(t, err, codes.Internal)
@@ -1220,7 +1220,7 @@ func TestNodeExpandVolume(t *testing.T) {
 				node := newTestNodeServiceExpand(mockNodeUtils, mockOsDeviceConHelper, mockMounter)
 
 				mockNodeUtils.EXPECT().GetVolumeUuid(volId).Return(volId)
-				mockOsDeviceConHelper.EXPECT().GetMpathDevice(volId).Return(mpathDevice, nil)
+				mockNodeUtils.EXPECT().DiscoverMpathDevice(volId).Return(mpathDevice, nil)
 				mockNodeUtils.EXPECT().DevicesAreNvme(dmSysFsName).Return(driver.NotNVMe, nil)
 				mockNodeUtils.EXPECT().GetSysDevicesFromMpath(dmSysFsName).Return(nil, dummyError)
 
@@ -1239,7 +1239,7 @@ func TestNodeExpandVolume(t *testing.T) {
 				node := newTestNodeServiceExpand(mockNodeUtils, mockOsDeviceConHelper, mockMounter)
 
 				mockNodeUtils.EXPECT().GetVolumeUuid(volId).Return(volId)
-				mockOsDeviceConHelper.EXPECT().GetMpathDevice(volId).Return(mpathDevice, nil)
+				mockNodeUtils.EXPECT().DiscoverMpathDevice(volId).Return(mpathDevice, nil)
 				mockNodeUtils.EXPECT().DevicesAreNvme(dmSysFsName).Return(driver.NotNVMe, nil)
 				mockNodeUtils.EXPECT().GetSysDevicesFromMpath(dmSysFsName).Return(sysDevices, nil)
 				mockNodeUtils.EXPECT().RescanPhysicalDevices(sysDevices).Return(dummyError)
@@ -1259,7 +1259,7 @@ func TestNodeExpandVolume(t *testing.T) {
 				node := newTestNodeServiceExpand(mockNodeUtils, mockOsDeviceConHelper, mockMounter)
 
 				mockNodeUtils.EXPECT().GetVolumeUuid(volId).Return(volId)
-				mockOsDeviceConHelper.EXPECT().GetMpathDevice(volId).Return(mpathDevice, nil)
+				mockNodeUtils.EXPECT().DiscoverMpathDevice(volId).Return(mpathDevice, nil)
 				mockNodeUtils.EXPECT().DevicesAreNvme(dmSysFsName).Return(driver.NotNVMe, nil)
 				mockNodeUtils.EXPECT().GetSysDevicesFromMpath(dmSysFsName).Return(sysDevices, nil)
 				mockNodeUtils.EXPECT().RescanPhysicalDevices(sysDevices).Return(nil)
@@ -1280,7 +1280,7 @@ func TestNodeExpandVolume(t *testing.T) {
 				node := newTestNodeServiceExpand(mockNodeUtils, mockOsDeviceConHelper, mockMounter)
 
 				mockNodeUtils.EXPECT().GetVolumeUuid(volId).Return(volId)
-				mockOsDeviceConHelper.EXPECT().GetMpathDevice(volId).Return(mpathDevice, nil)
+				mockNodeUtils.EXPECT().DiscoverMpathDevice(volId).Return(mpathDevice, nil)
 				mockNodeUtils.EXPECT().DevicesAreNvme(dmSysFsName).Return(driver.NotNVMe, nil)
 				mockNodeUtils.EXPECT().GetSysDevicesFromMpath(dmSysFsName).Return(sysDevices, nil)
 				mockNodeUtils.EXPECT().RescanPhysicalDevices(sysDevices).Return(nil)
@@ -1302,7 +1302,7 @@ func TestNodeExpandVolume(t *testing.T) {
 				node := newTestNodeServiceExpand(mockNodeUtils, mockOsDeviceConHelper, mockMounter)
 
 				mockNodeUtils.EXPECT().GetVolumeUuid(volId).Return(volId)
-				mockOsDeviceConHelper.EXPECT().GetMpathDevice(volId).Return(mpathDevice, nil)
+				mockNodeUtils.EXPECT().DiscoverMpathDevice(volId).Return(mpathDevice, nil)
 				mockNodeUtils.EXPECT().DevicesAreNvme(dmSysFsName).Return(driver.NotNVMe, nil)
 				mockNodeUtils.EXPECT().GetSysDevicesFromMpath(dmSysFsName).Return(sysDevices, nil)
 				mockNodeUtils.EXPECT().RescanPhysicalDevices(sysDevices).Return(nil)
@@ -1325,7 +1325,7 @@ func TestNodeExpandVolume(t *testing.T) {
 				node := newTestNodeServiceExpand(mockNodeUtils, mockOsDeviceConHelper, mockMounter)
 
 				mockNodeUtils.EXPECT().GetVolumeUuid(volId).Return(volId)
-				mockOsDeviceConHelper.EXPECT().GetMpathDevice(volId).Return(mpathDevice, nil)
+				mockNodeUtils.EXPECT().DiscoverMpathDevice(volId).Return(mpathDevice, nil)
 				mockNodeUtils.EXPECT().DevicesAreNvme(dmSysFsName).Return(driver.NVMeNonNative, nil)
 				mockNodeUtils.EXPECT().ExpandMpathDevice(dmSysFsName).Return(nil)
 				mockMounter.EXPECT().GetDiskFormat(mpathDevice).Return(fsType, nil)
@@ -1348,7 +1348,7 @@ func TestNodeExpandVolume(t *testing.T) {
 				node := newTestNodeServiceExpand(mockNodeUtils, mockOsDeviceConHelper, mockMounter)
 
 				mockNodeUtils.EXPECT().GetVolumeUuid(volId).Return(volId)
-				mockOsDeviceConHelper.EXPECT().GetMpathDevice(volId).Return(mpathDevice, nil)
+				mockNodeUtils.EXPECT().DiscoverMpathDevice(volId).Return(mpathDevice, nil)
 				mockNodeUtils.EXPECT().DevicesAreNvme(dmSysFsName).Return(driver.NVMeNative, nil)
 				// Native NVMe rescans the namespace instead of the dm-multipath device.
 				// No ExpandMpathDevice / GetSysDevicesFromMpath / RescanPhysicalDevices expected.
@@ -1373,7 +1373,7 @@ func TestNodeExpandVolume(t *testing.T) {
 				node := newTestNodeServiceExpand(mockNodeUtils, mockOsDeviceConHelper, mockMounter)
 
 				mockNodeUtils.EXPECT().GetVolumeUuid(volId).Return(volId)
-				mockOsDeviceConHelper.EXPECT().GetMpathDevice(volId).Return(mpathDevice, nil)
+				mockNodeUtils.EXPECT().DiscoverMpathDevice(volId).Return(mpathDevice, nil)
 				mockNodeUtils.EXPECT().DevicesAreNvme(dmSysFsName).Return(driver.NotNVMe, nil)
 				mockNodeUtils.EXPECT().GetSysDevicesFromMpath(dmSysFsName).Return(sysDevices, nil)
 				mockNodeUtils.EXPECT().RescanPhysicalDevices(sysDevices).Return(nil)

--- a/node/pkg/driver/node_utils.go
+++ b/node/pkg/driver/node_utils.go
@@ -78,6 +78,7 @@ type NodeUtilsInterface interface {
 	GetVolumeUuid(volumeId string) string
 	ReadNvmeNqn() (string, error)
 	IsNativeNVMeMultipathEnabled() (bool, error)
+	DiscoverMpathDevice(volumeUuid string) (string, error)
 	DevicesAreNvme(device string) (NvmeType, error)
 	ParseFCPorts() ([]string, error)
 	ParseIscsiInitiators() (string, error)
@@ -685,7 +686,7 @@ func (d NodeUtils) GetFileSystemVolumeStats(path string) (VolumeStatistics, erro
 
 func (d NodeUtils) GetBlockVolumeStats(volumeId string) (VolumeStatistics, error) {
 	volumeUuid := d.GetVolumeUuid(volumeId)
-	mpathDevice, err := d.getVolumeBlockDevice(volumeUuid)
+	mpathDevice, err := d.DiscoverMpathDevice(volumeUuid)
 	if err != nil {
 		return VolumeStatistics{}, err
 	}
@@ -709,16 +710,23 @@ func (d NodeUtils) GetBlockVolumeStats(volumeId string) (VolumeStatistics, error
 	return volumeStats, nil
 }
 
-// getVolumeBlockDevice resolves the host block device for a volume. NodeGetVolumeStats
-// has no connectivity dispatch, so native NVMe is handled here: resolve the namespace
-// head by NGUID (no dm device exists), otherwise use the shared dm-multipath discovery.
-func (d NodeUtils) getVolumeBlockDevice(volumeUuid string) (string, error) {
+// DiscoverMpathDevice resolves the host block device for a volume, native-aware, for the
+// node RPCs that have no connectivity-type dispatch (unstage, publish raw-block, expand,
+// volume stats). In native NVMe mode it resolves the namespace head by NGUID; a miss
+// falls through to dm-multipath discovery so a SCSI/iSCSI volume on a native-NVMe host
+// still resolves (the two device namespaces are disjoint, so there is no false match).
+// The native lookup is single-shot: at these call sites the device is already staged, so
+// no udev settle wait is needed, and a SCSI volume does not stall before the dm fallback.
+func (d NodeUtils) DiscoverMpathDevice(volumeUuid string) (string, error) {
 	native, err := d.IsNativeNVMeMultipathEnabled()
 	if err != nil {
-		logger.Warningf("getVolumeBlockDevice: could not determine multipath mode: %v; using dm discovery", err)
+		logger.Warningf("DiscoverMpathDevice: could not determine multipath mode: %v; using dm discovery", err)
 	}
 	if native {
-		return device_connectivity.DiscoverNativeNamespaceDevice(d.Executer, volumeUuid)
+		if device, nerr := device_connectivity.DiscoverNativeNamespaceDevice(d.Executer, volumeUuid, 1); nerr == nil {
+			return device, nil
+		}
+		logger.Debugf("DiscoverMpathDevice: no native NVMe namespace for %s, falling back to dm discovery", volumeUuid)
 	}
 	return d.osDeviceConnectivityHelper.GetMpathDevice(volumeUuid)
 }

--- a/node/pkg/driver/node_utils.go
+++ b/node/pkg/driver/node_utils.go
@@ -218,15 +218,9 @@ func (n NodeUtils) StageInfoFileIsExist(filePath string) bool {
 }
 
 func (n NodeUtils) IsNativeNVMeMultipathEnabled() (bool, error) {
-	data, err := os.ReadFile("/sys/module/nvme_core/parameters/multipath")
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, fmt.Errorf("failed to read nvme_core multipath param: %w", err)
-	}
-	val := strings.TrimSpace(string(data))
-	return val == "Y", nil
+	// Delegate to the single source of truth in device_connectivity (Executer-backed,
+	// so it is fake-able in tests and reads the shared sysfs param path constant).
+	return device_connectivity.IsNvmeCoreMultipathEnabled(n.Executer)
 }
 
 func (n NodeUtils) DevicesAreNvme(device string) (NvmeType, error) {

--- a/node/pkg/driver/node_utils.go
+++ b/node/pkg/driver/node_utils.go
@@ -677,7 +677,7 @@ func (d NodeUtils) GetFileSystemVolumeStats(path string) (VolumeStatistics, erro
 
 func (d NodeUtils) GetBlockVolumeStats(volumeId string) (VolumeStatistics, error) {
 	volumeUuid := d.GetVolumeUuid(volumeId)
-	mpathDevice, err := d.osDeviceConnectivityHelper.GetMpathDevice(volumeUuid)
+	mpathDevice, err := d.getVolumeBlockDevice(volumeUuid)
 	if err != nil {
 		return VolumeStatistics{}, err
 	}
@@ -699,6 +699,20 @@ func (d NodeUtils) GetBlockVolumeStats(volumeId string) (VolumeStatistics, error
 	}
 
 	return volumeStats, nil
+}
+
+// getVolumeBlockDevice resolves the host block device for a volume. NodeGetVolumeStats
+// has no connectivity dispatch, so native NVMe is handled here: resolve the namespace
+// head by NGUID (no dm device exists), otherwise use the shared dm-multipath discovery.
+func (d NodeUtils) getVolumeBlockDevice(volumeUuid string) (string, error) {
+	native, err := d.IsNativeNVMeMultipathEnabled()
+	if err != nil {
+		logger.Warningf("getVolumeBlockDevice: could not determine multipath mode: %v; using dm discovery", err)
+	}
+	if native {
+		return device_connectivity.DiscoverNativeNamespaceDevice(d.Executer, volumeUuid)
+	}
+	return d.osDeviceConnectivityHelper.GetMpathDevice(volumeUuid)
 }
 
 func (d NodeUtils) GetVolumeUuid(volumeId string) string {

--- a/node/pkg/driver/node_utils.go
+++ b/node/pkg/driver/node_utils.go
@@ -97,6 +97,7 @@ type NodeUtilsInterface interface {
 	ExpandFilesystem(devicePath string, volumePath string, fsType string) error
 	ExpandMpathDevice(mpathDevice string) error
 	RescanPhysicalDevices(sysDevices []string) error
+	RescanNvmeNamespace(namespaceDevice string) error
 	FormatDevice(devicePath string, fsType string)
 	IsNotMountPoint(file string) (bool, error)
 	GetPodPath(filepath string) string
@@ -509,6 +510,13 @@ func (n NodeUtils) RescanPhysicalDevices(sysDevices []string) error {
 	}
 	logger.Debugf("Rescan : finish rescan on sys devices : {%v}", sysDevices)
 	return nil
+}
+
+// RescanNvmeNamespace refreshes a native NVMe namespace's size after an array-side
+// expand by rescanning its subsystem controllers (native multipath has no dm device to
+// resize). Best-effort — see device_connectivity.RescanNvmeNamespaceForResize.
+func (n NodeUtils) RescanNvmeNamespace(namespaceDevice string) error {
+	return device_connectivity.RescanNvmeNamespaceForResize(n.Executer, namespaceDevice)
 }
 
 func (n NodeUtils) FormatDevice(devicePath string, fsType string) {

--- a/node/pkg/driver/node_utils_test.go
+++ b/node/pkg/driver/node_utils_test.go
@@ -390,6 +390,9 @@ func TestGetBlockVolumeStats(t *testing.T) {
 			nodeUtils := driver.NewNodeUtils(fakeExecuter, nil, ConfigYaml, mockOsDeviceConHelper)
 			args := []string{"--getsize64", tc.mpathDevice}
 
+			// dm-multipath mode: DiscoverMpathDevice reads the mode then uses the dm helper.
+			fakeExecuter.EXPECT().IoutilReadFile("/sys/module/nvme_core/parameters/multipath").
+				Return([]byte("N"), nil).AnyTimes()
 			mockOsDeviceConHelper.EXPECT().GetMpathDevice(tc.volumeUuid).Return(tc.mpathDevice, tc.mpathDeviceErr)
 			if tc.mpathDevice != "" {
 				fakeExecuter.EXPECT().ExecuteWithTimeoutSilently(
@@ -414,4 +417,73 @@ func assertExpectedError(t *testing.T, expectedError error, responseErr error) {
 	if expectedError != responseErr {
 		t.Fatalf("wrong error: expected %v, got %v", expectedError, responseErr)
 	}
+}
+
+func TestDiscoverMpathDevice(t *testing.T) {
+	const (
+		coreParam = "/sys/module/nvme_core/parameters/multipath"
+		volUID    = "60050768108187245800000000000039"
+		nguid     = "58000000000000390050760810818724"
+		byIdPath  = "/dev/disk/by-id/nvme-eui." + nguid
+	)
+
+	t.Run("native mode resolves the namespace head by NGUID", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		exec := mocks.NewMockExecuterInterface(mockCtrl)
+		helper := mocks.NewMockOsDeviceConnectivityHelperScsiGenericInterface(mockCtrl)
+		nu := driver.NewNodeUtils(exec, nil, ConfigYaml, helper)
+
+		exec.EXPECT().IoutilReadFile(coreParam).Return([]byte("Y"), nil)
+		exec.EXPECT().OsReadlink(byIdPath).Return("../../nvme1n1", nil)
+		// dm helper must NOT be called in native mode when the head resolves.
+
+		got, err := nu.DiscoverMpathDevice(volUID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "/dev/nvme1n1" {
+			t.Fatalf("expected /dev/nvme1n1, got %s", got)
+		}
+	})
+
+	t.Run("native mode miss falls back to dm discovery (SCSI/iSCSI on native host)", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		exec := mocks.NewMockExecuterInterface(mockCtrl)
+		helper := mocks.NewMockOsDeviceConnectivityHelperScsiGenericInterface(mockCtrl)
+		nu := driver.NewNodeUtils(exec, nil, ConfigYaml, helper)
+
+		exec.EXPECT().IoutilReadFile(coreParam).Return([]byte("Y"), nil)
+		exec.EXPECT().OsReadlink(byIdPath).Return("", os.ErrNotExist)
+		exec.EXPECT().FilepathGlob("/sys/block/nvme*/wwid").Return([]string{}, nil)
+		helper.EXPECT().GetMpathDevice(volUID).Return("/dev/dm-3", nil)
+
+		got, err := nu.DiscoverMpathDevice(volUID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "/dev/dm-3" {
+			t.Fatalf("expected dm fallback /dev/dm-3, got %s", got)
+		}
+	})
+
+	t.Run("dm mode uses dm discovery directly", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		exec := mocks.NewMockExecuterInterface(mockCtrl)
+		helper := mocks.NewMockOsDeviceConnectivityHelperScsiGenericInterface(mockCtrl)
+		nu := driver.NewNodeUtils(exec, nil, ConfigYaml, helper)
+
+		exec.EXPECT().IoutilReadFile(coreParam).Return([]byte("N"), nil)
+		helper.EXPECT().GetMpathDevice(volUID).Return("/dev/dm-5", nil)
+
+		got, err := nu.DiscoverMpathDevice(volUID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "/dev/dm-5" {
+			t.Fatalf("expected /dev/dm-5, got %s", got)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Adds full native-ANA multipath support for NVMe-oF/FC to the node driver. On arrays that present ANA (native `nvme_core` multipath, `multipath=Y`), device discovery for stage/publish/expand/stats must target the native NVMe namespace head (`/dev/nvmeXnY`, resolved by NGUID) instead of a dm-multipath device. This series makes every node-side discovery path native-aware while preserving the existing dm-multipath (non-native) behaviour unchanged.

Based directly on `release-1.14.0` (no divergence) and leaves the driver version unchanged.

## What changed

- **Native namespace discovery by NGUID** — resolve the ANA namespace head from the volume's NGUID so stage/publish target the correct native device.
- **Consolidated native-multipath detection** — one Executer-backed helper is the single source of truth for native (`nvme_core` multipath) vs non-native (dm), used across the lifecycle.
- **Stage** — skip dm sys-device discovery for native NVMe; rescan namespaces on already-connected controllers so a LUN mapped after controller login (missed AEN) is found instead of failing the stage.
- **Unstage / publish / expand / stats** — route device discovery through the native-aware resolver when native, dm otherwise.
- **Expand** — rescan the native namespace on `NodeExpandVolume` so the device sees the grown capacity (avoids under-growth).
- **NodeGetVolumeStats** — support native NVMe for both block and filesystem volumes.
- **Path accounting** — normalize the `0x` traddr prefix in `EnsureLogin` so publish-context target ports match `nvme list-subsys` output regardless of the kernel hex prefix (prevents mis-counting live paths).

## Tests

Unit coverage lands with the series: `device_connectivity_nvmeofc_native_test.go` (native discovery/lifecycle), additions to `device_connectivity_nvmeofc_internal_test.go` and `device_connectivity_nvmeofc_test.go`, plus `node_test.go` / `node_utils_test.go` for native routing in the node service.

`make test` and `go test -race ./node/...` both pass on Linux against the module's pinned deps (`go 1.25.10`, `k8s.io/mount-utils v0.35.0`); no data races.

## Notes

- No version bump; `common/config.yaml` and the Dockerfiles are untouched.
- Non-native / dm-multipath behaviour is preserved — native paths are taken only when `nvme_core` multipath is active.

_Draft: opening for maintainer review of the approach before finalizing._
