### PR TITLE
Fix: pass space_efficiency through FC2 non-partition clone path

### DIFF
--- a/controllers/array_action/array_mediator_svc.py
+++ b/controllers/array_action/array_mediator_svc.py
@@ -125,7 +125,7 @@ def _is_space_efficiency_matches_source(parameter_space_efficiency, array_space_
            (parameter_space_efficiency and parameter_space_efficiency == array_space_efficiency)
 
 
-def build_create_volume_in_volume_group_kwargs(pool, io_group, source_id):
+def build_create_volume_in_volume_group_kwargs(pool, io_group, source_id, space_efficiency=None):
     cli_kwargs = {
         'type': 'clone',
         'fromsnapshotid': source_id,
@@ -133,6 +133,8 @@ def build_create_volume_in_volume_group_kwargs(pool, io_group, source_id):
     }
     if io_group:
         cli_kwargs['iogroup'] = io_group
+    space_efficiency_kwargs = _get_space_efficiency_kwargs(space_efficiency)
+    cli_kwargs.update(space_efficiency_kwargs)
     return cli_kwargs
 
 
@@ -769,8 +771,8 @@ class SVCArrayMediator(ArrayMediatorAbstract, VolumeGroupInterface):
             return False
         return (self._get_pool_site(pool.split(":")[0]) != self._get_pool_site(pool.split(":")[1]))
 
-    def _create_volume_in_volume_group(self, name, pool, io_group, source_id):
-        cli_kwargs = build_create_volume_in_volume_group_kwargs(pool, io_group, source_id)
+    def _create_volume_in_volume_group(self, name, pool, io_group, source_id, space_efficiency=None):
+        cli_kwargs = build_create_volume_in_volume_group_kwargs(pool, io_group, source_id, space_efficiency)
         self._mkvolumegroup(name, **cli_kwargs)
 
     def _fix_creation_side_effects(self, name, cli_volume_id, volume_group):
@@ -786,11 +788,11 @@ class SVCArrayMediator(ArrayMediatorAbstract, VolumeGroupInterface):
             logger.info("adding vdisk copy to pool: {}".format(additional_pool))
             self.client.svctask.addvdiskcopy(mdiskgrp=additional_pool, vdisk_id=vdisk_id)
 
-    def _create_cli_volume_from_snapshot(self, name, pool, io_group, volume_group, source_id):
+    def _create_cli_volume_from_snapshot(self, name, pool, io_group, volume_group, source_id, space_efficiency=None):
         logger.info("creating volume from snapshot. pool: {}".format(pool))
         is_stretch = self._is_stretch_pool(pool)
         vg_pool = pool.split(":")[0] if is_stretch else pool
-        self._create_volume_in_volume_group(name, vg_pool, io_group, source_id)
+        self._create_volume_in_volume_group(name, vg_pool, io_group, source_id, space_efficiency)
         cli_volume_id = self._get_cli_volume_id_from_volume_group("volume_group_name", name)
         try:
             # remove vg and leave volume, with name <name>
@@ -823,11 +825,12 @@ class SVCArrayMediator(ArrayMediatorAbstract, VolumeGroupInterface):
             logger.debug("Error running mkvolume -name {} {}".format(name, self._format_cli_args(cli_kwargs)))
             raise ex
 
-    def _create_cli_volume_from_volume(self, name, pool, io_group, volume_group, source_id):
+    def _create_cli_volume_from_volume(self, name, pool, io_group, volume_group, source_id, space_efficiency=None):
         logger.info("creating volume from volume")
         cli_snapshot = self._add_snapshot(name, source_id, pool)
         try:
-            self._create_cli_volume_from_snapshot(name, pool, io_group, volume_group, cli_snapshot.snapshot_id)
+            self._create_cli_volume_from_snapshot(name, pool, io_group, volume_group, cli_snapshot.snapshot_id,
+                                                  space_efficiency)
         finally:
             self._rmsnapshot(cli_snapshot.snapshot_id)
 
@@ -900,11 +903,14 @@ class SVCArrayMediator(ArrayMediatorAbstract, VolumeGroupInterface):
         self._partition_create_cli_volume_from_cli_vol(name, pool, io_group, volume_group, cli_volume,
                                                        space_efficiency, partition_name)
 
-    def _create_cli_volume_from_source(self, name, pool, io_group, volume_group, source_ids, source_type):
+    def _create_cli_volume_from_source(self, name, pool, io_group, volume_group, source_ids, source_type,
+                                       space_efficiency=None):
         if source_type == controller_settings.SNAPSHOT_TYPE_NAME:
-            self._create_cli_volume_from_snapshot(name, pool, io_group, volume_group, source_ids.internal_id)
+            self._create_cli_volume_from_snapshot(name, pool, io_group, volume_group, source_ids.internal_id,
+                                                  space_efficiency)
         else:
-            self._create_cli_volume_from_volume(name, pool, io_group, volume_group, source_ids.internal_id)
+            self._create_cli_volume_from_volume(name, pool, io_group, volume_group, source_ids.internal_id,
+                                                space_efficiency)
 
     def _is_vdisk_support_addsnapshot(self, vdisk_uid):
         return self._is_addsnapshot_supported() and not self._is_vdisk_has_fcmaps(vdisk_uid)
@@ -940,7 +946,7 @@ class SVCArrayMediator(ArrayMediatorAbstract, VolumeGroupInterface):
         if is_virt_snap_func and source_ids:
             if self._is_vdisk_support_addsnapshot(source_ids.uid):
                 self._create_cli_volume_from_source(name, pool, io_group, volume_group, source_ids,
-                                                    source_type)
+                                                    source_type, space_efficiency)
             else:
                 raise array_errors.VirtSnapshotFunctionNotSupportedMessage(name)
         else:

--- a/controllers/tests/array_action/svc/array_mediator_svc_test.py
+++ b/controllers/tests/array_action/svc/array_mediator_svc_test.py
@@ -504,17 +504,20 @@ class TestArrayMediatorSVC(unittest.TestCase):
                                                             size=array_settings.DUMMY_CAPACITY_INT,
                                                             pool=common_settings.DUMMY_POOL1)
 
-    def _test_create_volume_mkvolumegroup_success(self, source_type):
+    def _test_create_volume_mkvolumegroup_success(self, source_type, space_efficiency=None):
         self._prepare_mocks_for_create_volume_mkvolumegroup()
         if source_type == common_settings.VOLUME_OBJECT_TYPE:
             self._prepare_mocks_for_create_snapshot_addsnapshot(snapshot_id=common_settings.INTERNAL_SNAPSHOT_ID)
         self._test_create_volume_success(source_id=common_settings.INTERNAL_SNAPSHOT_ID, source_type=source_type,
-                                         is_virt_snap_func=True)
+                                         is_virt_snap_func=True, space_efficiency=space_efficiency)
 
-        self.svc.client.svctask.mkvolumegroup.assert_called_with(type=svc_settings.MKVOLUMEGROUP_CLONE_TYPE,
-                                                                 fromsnapshotid=common_settings.INTERNAL_SNAPSHOT_ID,
-                                                                 pool=common_settings.DUMMY_POOL1,
-                                                                 name=common_settings.VOLUME_NAME)
+        expected_kwargs = dict(type=svc_settings.MKVOLUMEGROUP_CLONE_TYPE,
+                               fromsnapshotid=common_settings.INTERNAL_SNAPSHOT_ID,
+                               pool=common_settings.DUMMY_POOL1,
+                               name=common_settings.VOLUME_NAME)
+        if space_efficiency == SPACE_EFFICIENCY_DEDUPLICATED_THIN:
+            expected_kwargs.update(thin=True, deduplicated=True)
+        self.svc.client.svctask.mkvolumegroup.assert_called_with(**expected_kwargs)
         remove_from_volumegroup_call = call(vdisk_id=common_settings.INTERNAL_VOLUME_ID, novolumegroup=True)
         rename_call = call(vdisk_id=common_settings.INTERNAL_VOLUME_ID, name=common_settings.VOLUME_NAME)
         self.svc.client.svctask.chvdisk.assert_has_calls([remove_from_volumegroup_call, rename_call])
@@ -525,6 +528,14 @@ class TestArrayMediatorSVC(unittest.TestCase):
 
     def test_create_volume_mkvolumegroup_from_volume_success(self):
         self._test_create_volume_mkvolumegroup_success(source_type=common_settings.VOLUME_OBJECT_TYPE)
+
+    def test_create_volume_mkvolumegroup_from_snapshot_with_dedup_thin_space_efficiency_success(self):
+        self._test_create_volume_mkvolumegroup_success(source_type=common_settings.SNAPSHOT_OBJECT_TYPE,
+                                                       space_efficiency=SPACE_EFFICIENCY_DEDUPLICATED_THIN)
+
+    def test_create_volume_mkvolumegroup_from_volume_with_dedup_thin_space_efficiency_success(self):
+        self._test_create_volume_mkvolumegroup_success(source_type=common_settings.VOLUME_OBJECT_TYPE,
+                                                       space_efficiency=SPACE_EFFICIENCY_DEDUPLICATED_THIN)
 
     def test_is_stretch_pool_with_stretch_pool_returns_true(self):
         pools_to_return = [Munch({svc_settings.LSMDISKGRP_SITE_NAME_ATTR_KEY: svc_settings.DUMMY_POOL_SITE}),


### PR DESCRIPTION
When cloning a PVC with space_efficiency (e.g. dedup_thin) using the FC2/virt_snap_func path, the space_efficiency value was received by create_volume() but silently dropped before reaching the mkvolumegroup CLI call. As a result, the cloned volume on the array was created without the deduplicated/thin flags, regardless of what space_efficiency was specified in the StorageClass.

Root cause: five functions in the non-partition FC2 clone chain had no space_efficiency parameter:

  _create_cli_volume_from_source()
  _create_cli_volume_from_volume()
  _create_cli_volume_from_snapshot()
  _create_volume_in_volume_group()
  build_create_volume_in_volume_group_kwargs()

Fix: thread space_efficiency as an optional parameter through all five functions and apply _get_space_efficiency_kwargs() at the bottom of the chain in build_create_volume_in_volume_group_kwargs(), mirroring what the partition path (_create_cli_volume_from_vg_snapshot) already does correctly.

Note: creating a fresh volume (no dataSource) was never affected — that path goes through _create_cli_volume() -> build_kwargs_from_parameters() which always handled space_efficiency correctly.

Add unit tests covering dedup_thin clone-from-snapshot and clone-from-volume to prevent regression.